### PR TITLE
Remove deriving yaml to make rescript happy

### DIFF
--- a/src/ood/ood.mli
+++ b/src/ood/ood.mli
@@ -237,7 +237,7 @@ module Workshop : sig
 
   val role_of_string : string -> (role, [> `Msg of string ]) result
 
-  type important_date = { date : string; info : string } [@@deriving yaml]
+  type important_date = { date : string; info : string }
 
   type committee_member = {
     name : string;


### PR DESCRIPTION
Slipped passed me in #60 -- we need CI to check v3.ocaml.org and ood compatibility.