### PR TITLE
Initial v3 ci implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,22 @@ jobs:
       - name: Run the unit tests
         run: opam exec -- dune runtest --root . --ignore-promoted-rules
         timeout-minutes: 1
+  v3-ocaml-org:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout v3.ocaml.org
+        uses: actions/checkout@v2
+        with:
+          repository: 'ocaml/v3.ocaml.org'
+      - name: Vendor this ood
+        run: |
+          cd vendor
+          sed -i 's/git checkout \$version/git fetch origin $GITHUB_REF:test-ood \&\& git checkout test-ood/g' update-ood.sh
+          ./update-ood.sh
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - name: Install and build
+        run: |
+          make install-deps
+          make build


### PR DESCRIPTION
This PR tries to add a compatibility check with [v3.ocaml.org](https://github.com/ocaml/v3.ocaml.org) as a next step from #61  -- I'm not quite sure what are vendoring story is for v3, right now it seems `make vendor/ood` is always coming back as "nothing to do", I was prototyping something and needed the latest ood so I forced it to get the latest version and that's when I noticed #61.

Whether we're manually vendoring it (if that's the plan we should probably just be using submodules instead of a shell script, this also makes it easier to prototype locally I think) or always taking the latest, I still think a CI check in ood is a good thing.