### PR TITLE
Remove french tutorials

### DIFF
--- a/data/tutorials/fr/introduction.md
+++ b/data/tutorials/fr/introduction.md
@@ -1,6 +1,0 @@
----
-title: Première heure avec OCaml
-description: Découvre OCaml dans ce tutoriel TODO
-date: 2021-05-18T11:51:18.791Z
----
-# TODO


### PR DESCRIPTION
This PR removes the current placeholder for the french tutorials.

I've looked into the french tutorials in ocaml.org, and for the most part, they either seem incomplete or outdated.
In their current state, I don't think we should import them, and I would suggest that we create an issue to translate them instead (and eventually copy the bits that are already translated and up to date when doing so).