### PR TITLE
Add opam users

### DIFF
--- a/data/opam-users.yml
+++ b/data/opam-users.yml
@@ -1,0 +1,50 @@
+opam-users:
+
+  - name: "Xavier Leroy"
+    github_username: "xavierleroy"
+    avatar: "https://avatars.githubusercontent.com/u/3845810?v=4"
+
+  - name: "Damien Doligez"
+    github_username: "damiendoligez"
+    avatar: "https://avatars.githubusercontent.com/u/19104?v=4"
+
+  - name: "David Allsopp"
+    github_username: "dra27"
+    avatar: "https://avatars.githubusercontent.com/u/5250680?v=4"
+
+  - name: "Alain Frisch"
+    github_username: "alainfrisch"
+    avatar: "https://avatars.githubusercontent.com/u/3305274?v=4"
+
+  - name: "Gabriel Scherer"
+    github_username: "gasche"
+    avatar: "https://avatars.githubusercontent.com/u/426238?v=4"
+
+  - name: "Jacques Garrigue"
+    github_username: "garrigue"
+    avatar: "https://avatars.githubusercontent.com/u/870242?v=4"
+
+  - name: "Thibaut Mattio"
+    email: thibaut.mattio@gmail.com
+    github_username: "tmattio"
+    avatar: "https://avatars.githubusercontent.com/u/6162008?v=4"
+
+  - name: "Anton Bachin"
+    github_username: "aantron"
+    avatar: "https://avatars.githubusercontent.com/u/12073668?v=4"
+
+  - name: "Patrick Ferris"
+    github_username: "patricoferris"
+    avatar: "https://avatars.githubusercontent.com/u/20166594?v=4"
+
+  - name: "Didier Rémy"
+    github_username: "diremy"
+    avatar: "https://avatars.githubusercontent.com/u/1357930?v=4"
+
+  - name: "Gabriel Radanne"
+    github_username: "Drup"
+    avatar: "https://avatars.githubusercontent.com/u/801124?v=4"
+
+  - name: "Daniel Bünzli"
+    github_username: "dbuenzli"
+    avatar: "https://avatars.githubusercontent.com/u/485596?v=4"

--- a/src/ood-gen/bin/gen.ml
+++ b/src/ood-gen/bin/gen.ml
@@ -14,6 +14,7 @@ let term_templates =
     ("video", Ood_gen.Video.template);
     ("watch", Ood_gen.Watch.template);
     ("news", Ood_gen.News.template);
+    ("opam_user", Ood_gen.Opam_user.template);
   ]
 
 let cmds =

--- a/src/ood-gen/lib/opam_user.ml
+++ b/src/ood-gen/lib/opam_user.ml
@@ -1,0 +1,77 @@
+type metadata = {
+  name : string;
+  email : string option;
+  github_username : string;
+  avatar : string;
+}
+[@@deriving yaml]
+
+let path = Fpath.v "data/opam-users.yml"
+
+type t = {
+  name : string;
+  email : string option;
+  github_username : string;
+  avatar : string;
+}
+
+let parse s =
+  let yaml = Utils.decode_or_raise Yaml.of_string s in
+  match yaml with
+  | `O [ ("opam-users", `A xs) ] ->
+      Ok (List.map (fun x -> Utils.decode_or_raise metadata_of_yaml x) xs)
+  | _ -> Error (`Msg "Expected list of opam-users")
+
+let decode s =
+  let yaml = Utils.decode_or_raise Yaml.of_string s in
+  match yaml with
+  | `O [ ("opam-users", `A xs) ] ->
+      List.map
+        (fun x ->
+          try
+            let (metadata : metadata) =
+              Utils.decode_or_raise metadata_of_yaml x
+            in
+            ({
+               name = metadata.name;
+               email = metadata.email;
+               github_username = metadata.github_username;
+               avatar = metadata.avatar;
+             }
+              : t)
+          with e ->
+            print_endline (Yaml.to_string x |> Result.get_ok);
+            raise e)
+        xs
+  | _ -> raise (Exn.Decode_error "expected a list of opam-users")
+
+let all () =
+  let content = Data.read "opam-users.yml" |> Option.get in
+  decode content
+
+let pp ppf v =
+  Fmt.pf ppf
+    {|
+  { name = %a
+  ; email = %a
+  ; github_username = %a
+  ; avatar = %a
+  }|}
+    Pp.string v.name (Pp.option Pp.string) v.email Pp.string v.github_username
+    Pp.string v.avatar
+
+let pp_list = Pp.list pp
+
+let template () =
+  Format.asprintf
+    {|
+type t =
+  { name : string
+  ; email : string option
+  ; github_username : string
+  ; avatar : string
+  }
+  
+let all = %a
+|}
+    pp_list (all ())

--- a/src/ood/dune
+++ b/src/ood/dune
@@ -114,6 +114,16 @@
 
 (rule
  (deps %{bin:ood-gen})
+ (targets opam_user.ml)
+ (mode
+  (promote (until-clean)))
+ (action
+  (with-stdout-to
+   %{targets}
+   (run %{deps} opam_user))))
+
+(rule
+ (deps %{bin:ood-gen})
  (targets workshop.ml)
  (mode
   (promote (until-clean)))

--- a/src/ood/ood.ml
+++ b/src/ood/ood.ml
@@ -96,6 +96,10 @@ module News = struct
   let get_by_slug slug = List.find_opt (fun x -> String.equal slug x.slug) all
 end
 
+module Opam_user = struct
+  include Opam_user
+end
+
 module Watch = struct
   include Watch
 

--- a/src/ood/ood.mli
+++ b/src/ood/ood.mli
@@ -230,6 +230,17 @@ module News : sig
   val get_by_slug : string -> t option
 end
 
+module Opam_user : sig
+  type t = {
+    name : string;
+    email : string option;
+    github_username : string;
+    avatar : string;
+  }
+
+  val all : t list
+end
+
 module Workshop : sig
   type role = [ `Co_chair | `Chair ]
 

--- a/src/ood/opam_user.ml
+++ b/src/ood/opam_user.ml
@@ -1,0 +1,82 @@
+
+type t =
+  { name : string
+  ; email : string option
+  ; github_username : string
+  ; avatar : string
+  }
+  
+let all = 
+[
+  { name = {js|Xavier Leroy|js}
+  ; email = None
+  ; github_username = {js|xavierleroy|js}
+  ; avatar = {js|https://avatars.githubusercontent.com/u/3845810?v=4|js}
+  };
+ 
+  { name = {js|Damien Doligez|js}
+  ; email = None
+  ; github_username = {js|damiendoligez|js}
+  ; avatar = {js|https://avatars.githubusercontent.com/u/19104?v=4|js}
+  };
+ 
+  { name = {js|David Allsopp|js}
+  ; email = None
+  ; github_username = {js|dra27|js}
+  ; avatar = {js|https://avatars.githubusercontent.com/u/5250680?v=4|js}
+  };
+ 
+  { name = {js|Alain Frisch|js}
+  ; email = None
+  ; github_username = {js|alainfrisch|js}
+  ; avatar = {js|https://avatars.githubusercontent.com/u/3305274?v=4|js}
+  };
+ 
+  { name = {js|Gabriel Scherer|js}
+  ; email = None
+  ; github_username = {js|gasche|js}
+  ; avatar = {js|https://avatars.githubusercontent.com/u/426238?v=4|js}
+  };
+ 
+  { name = {js|Jacques Garrigue|js}
+  ; email = None
+  ; github_username = {js|garrigue|js}
+  ; avatar = {js|https://avatars.githubusercontent.com/u/870242?v=4|js}
+  };
+ 
+  { name = {js|Thibaut Mattio|js}
+  ; email = Some {js|thibaut.mattio@gmail.com|js}
+  ; github_username = {js|tmattio|js}
+  ; avatar = {js|https://avatars.githubusercontent.com/u/6162008?v=4|js}
+  };
+ 
+  { name = {js|Anton Bachin|js}
+  ; email = None
+  ; github_username = {js|aantron|js}
+  ; avatar = {js|https://avatars.githubusercontent.com/u/12073668?v=4|js}
+  };
+ 
+  { name = {js|Patrick Ferris|js}
+  ; email = None
+  ; github_username = {js|patricoferris|js}
+  ; avatar = {js|https://avatars.githubusercontent.com/u/20166594?v=4|js}
+  };
+ 
+  { name = {js|Didier Rémy|js}
+  ; email = None
+  ; github_username = {js|diremy|js}
+  ; avatar = {js|https://avatars.githubusercontent.com/u/1357930?v=4|js}
+  };
+ 
+  { name = {js|Gabriel Radanne|js}
+  ; email = None
+  ; github_username = {js|Drup|js}
+  ; avatar = {js|https://avatars.githubusercontent.com/u/801124?v=4|js}
+  };
+ 
+  { name = {js|Daniel Bünzli|js}
+  ; email = None
+  ; github_username = {js|dbuenzli|js}
+  ; avatar = {js|https://avatars.githubusercontent.com/u/485596?v=4|js}
+  }]
+


### PR DESCRIPTION
This allows us to add links to opam users' GitHub profiles in https://v3.ocaml.org/packages (e.g. https://v3.ocaml.org/p/spin/0.8.3) with their avatars.

I'm adding the users currently hardcoded in https://github.com/ocaml/v3.ocaml.org-server/blob/main/lib/ocamlorg/opam_user.ml, and will replace them once this PR is merged. This initial list is composed of people who contributed to v3.ocaml.org, maintainers of the OCaml's compiler, and a few opam users who wrote popular libraries.