### PR TITLE
fetch all of watch.ocaml.org videos

### DIFF
--- a/data/watch.yml
+++ b/data/watch.yml
@@ -3,9 +3,10 @@ watch:
   description: Professor Xavier Leroy -- the primary original author and leader of
     the OCaml project -- reflects on 25 years of the OCaml language at his OCaml Workshop
     2021 keynote speech.
-  embedPath: /videos/embed/e1ee0fc0-50ef-4a1c-894a-17df181424cb
-  thumbnailPath: /static/thumbnails/94ead657-79a0-4c10-8435-9e13906a6c44.jpg
-  date: 2021-08-27T13:23:10.199Z
+  embed_path: /videos/embed/e1ee0fc0-50ef-4a1c-894a-17df181424cb
+  thumbnail_path: /static/thumbnails/94ead657-79a0-4c10-8435-9e13906a6c44.jpg
+  published_at: 2021-08-27T13:23:10.199Z
+  updated_at: 2021-09-08T10:02:00.187Z
   language: English
   category: Science & Technology
 - name: A Declarative Syntax Definition for OCaml
@@ -13,9 +14,10 @@ watch:
     language in the syntax definition formalism SDF3. SDF3 supports the high-level
     definition of concrete and abstract syntax through declarative disambiguation
     and definition of c...
-  embedPath: /videos/embed/a5b86864-8e43-4138-b6d6-ed48d2d4b63d
-  thumbnailPath: /static/thumbnails/92c0a0e3-5326-42aa-86a3-6adb3927e111.jpg
-  date: 2020-08-28T00:00:00.000Z
+  embed_path: /videos/embed/a5b86864-8e43-4138-b6d6-ed48d2d4b63d
+  thumbnail_path: /static/thumbnails/92c0a0e3-5326-42aa-86a3-6adb3927e111.jpg
+  published_at: 2020-08-28T00:00:00.000Z
+  updated_at: 2021-09-01T04:02:00.070Z
   language: Unknown
   category: Misc
 - name: A Multiverse of Glorious Documentation
@@ -23,9 +25,10 @@ watch:
     version of every package that can be built from the opam repository, and how it
     is presented as a single coherent website that is continuously updated as new
     packages are releas...
-  embedPath: /videos/embed/9bb452d6-1829-4dac-a6a2-46b31050c931
-  thumbnailPath: /static/thumbnails/6a0a8291-4626-4820-8071-904b3c508345.jpg
-  date: 2021-08-27T11:23:36.000Z
+  embed_path: /videos/embed/9bb452d6-1829-4dac-a6a2-46b31050c931
+  thumbnail_path: /static/thumbnails/6a0a8291-4626-4820-8071-904b3c508345.jpg
+  published_at: 2021-08-27T11:23:36.000Z
+  updated_at: 2021-09-07T21:02:00.188Z
   language: English
   category: Science & Technology
 - name: A Simple State-Machine Framework for Property-Based Testing in OCaml
@@ -33,15 +36,17 @@ watch:
     worth by finding defects in everything from the underlying AUTOSAR components
     of Volvo cars to digital invoicing systems. These case studies were carried out
     with Erlang\u2019s commercia..."
-  embedPath: /videos/embed/08b429ea-2eb8-427d-a625-5495f4ee0fef
-  thumbnailPath: /static/thumbnails/316ddad9-dbc3-4d46-9f43-5da72689e93b.jpg
-  date: 2020-08-28T00:00:00.000Z
+  embed_path: /videos/embed/08b429ea-2eb8-427d-a625-5495f4ee0fef
+  thumbnail_path: /static/thumbnails/316ddad9-dbc3-4d46-9f43-5da72689e93b.jpg
+  published_at: 2020-08-28T00:00:00.000Z
+  updated_at: 2021-05-21T15:08:00.099Z
   language: Unknown
   category: Misc
 - name: A review of the growth of the OCaml community
-  embedPath: /videos/embed/f9d0b637-8aec-4bff-8c32-cd16b58023b6
-  thumbnailPath: /static/thumbnails/e573402b-1350-4aa7-a9ba-0e1c51198fb4.jpg
-  date: 2015-09-18T00:00:00.000Z
+  embed_path: /videos/embed/f9d0b637-8aec-4bff-8c32-cd16b58023b6
+  thumbnail_path: /static/thumbnails/e573402b-1350-4aa7-a9ba-0e1c51198fb4.jpg
+  published_at: 2015-09-18T00:00:00.000Z
+  updated_at: 2021-08-03T17:05:33.471Z
   language: Unknown
   category: Science & Technology
 - name: 'AD-OCaml: Algorithmic Differentiation for OCaml'
@@ -49,9 +54,10 @@ watch:
     derivatives and deep power series approximations of almost arbitrary OCaml programs
     via algorithmic differentiation. Unlike similar frameworks, this includes programs
     with side e...
-  embedPath: /videos/embed/c9e85690-732f-4b03-836f-2ee0fd8f0658
-  thumbnailPath: /static/thumbnails/eb972fd2-668e-4998-a798-e9fbdcadba20.jpg
-  date: 2020-08-28T00:00:00.000Z
+  embed_path: /videos/embed/c9e85690-732f-4b03-836f-2ee0fd8f0658
+  thumbnail_path: /static/thumbnails/eb972fd2-668e-4998-a798-e9fbdcadba20.jpg
+  published_at: 2020-08-28T00:00:00.000Z
+  updated_at: 2021-04-19T19:24:10.203Z
   language: Unknown
   category: Misc
 - name: 'API migration: compare transformed'
@@ -59,9 +65,10 @@ watch:
     strategy dedicated at changing the signatures of OCaml functions, using the Rotor
     refactoring tool for OCaml. We perform a case study on open source Jane Street
     libraries ...
-  embedPath: /videos/embed/c46b925b-bd77-404f-ac5d-5dab65047529
-  thumbnailPath: /static/thumbnails/eef64419-3c34-4c15-9419-edcbc455e54d.jpg
-  date: 2020-08-28T00:00:00.000Z
+  embed_path: /videos/embed/c46b925b-bd77-404f-ac5d-5dab65047529
+  thumbnail_path: /static/thumbnails/eef64419-3c34-4c15-9419-edcbc455e54d.jpg
+  published_at: 2020-08-28T00:00:00.000Z
+  updated_at: 2021-09-01T14:02:00.083Z
   language: Unknown
   category: Misc
 - name: Adapting the OCaml ecosystem for Multicore OCaml
@@ -69,9 +76,10 @@ watch:
     the corner, there\u2019s increasing interest in the community to port existing
     libraries to Multicore. This talk will take the attendees through what the arrival
     of Multicore means to th..."
-  embedPath: /videos/embed/629b89a8-bbd5-490d-98b0-d0c740912b02
-  thumbnailPath: /static/thumbnails/41212c84-36d6-44fa-b884-2ced79505929.jpg
-  date: 2021-08-27T10:18:38.000Z
+  embed_path: /videos/embed/629b89a8-bbd5-490d-98b0-d0c740912b02
+  thumbnail_path: /static/thumbnails/41212c84-36d6-44fa-b884-2ced79505929.jpg
+  published_at: 2021-08-27T10:18:38.000Z
+  updated_at: 2021-09-08T10:02:00.087Z
   language: English
   category: Science & Technology
 - name: Binary Analysis Platform
@@ -79,9 +87,10 @@ watch:
     program analysis framework for binaries that can leverage existing tools, libraries,
     and frameworks, no matter which intermediate representation (IR) they use. In
     BAP, a new IR c...
-  embedPath: /videos/embed/8dc2d8d3-c140-4c3d-a8fe-a6fcf6fba988
-  thumbnailPath: /static/thumbnails/390cd7dd-4578-4162-bae0-6c218cb5ebde.jpg
-  date: 2021-08-31T08:39:55.774Z
+  embed_path: /videos/embed/8dc2d8d3-c140-4c3d-a8fe-a6fcf6fba988
+  thumbnail_path: /static/thumbnails/390cd7dd-4578-4162-bae0-6c218cb5ebde.jpg
+  published_at: 2021-08-31T08:39:55.774Z
+  updated_at: 2021-09-04T14:02:00.212Z
   language: English
   category: Misc
 - name: Continuous Benchmarking for OCaml Projects
@@ -89,15 +98,17 @@ watch:
     stable performance over time. This makes them unsuitable for running performance
     benchmarks.\r\n\r\ncurrent-bench provides a predictable environment for performance
     benchmarks and a UI..."
-  embedPath: /videos/embed/1c994370-1aaa-4db6-b901-d762786e4904
-  thumbnailPath: /static/thumbnails/33ab36c3-3650-4c13-9fea-9b5907cf8c0f.jpg
-  date: 2021-08-27T11:20:09.000Z
+  embed_path: /videos/embed/1c994370-1aaa-4db6-b901-d762786e4904
+  thumbnail_path: /static/thumbnails/33ab36c3-3650-4c13-9fea-9b5907cf8c0f.jpg
+  published_at: 2021-08-27T11:20:09.000Z
+  updated_at: 2021-09-06T12:02:00.082Z
   language: English
   category: Science & Technology
 - name: 'Core Time stamp counter: A fast high resolution time source'
-  embedPath: /videos/embed/75b4d60f-3e37-40bd-b025-f39dcce0c42c
-  thumbnailPath: /static/thumbnails/43248673-6478-4e96-b8ac-cd415d85569b.jpg
-  date: 2015-09-18T00:00:00.000Z
+  embed_path: /videos/embed/75b4d60f-3e37-40bd-b025-f39dcce0c42c
+  thumbnail_path: /static/thumbnails/43248673-6478-4e96-b8ac-cd415d85569b.jpg
+  published_at: 2015-09-18T00:00:00.000Z
+  updated_at: 2021-08-03T16:29:56.317Z
   language: English
   category: Science & Technology
 - name: Deductive Verification of Realistic OCaml Code
@@ -105,9 +116,10 @@ watch:
     the OCaml standard library. The proof is conducted using Cameleer, a new tool
     for the deductive verification of OCaml code. Cameleer takes as input an OCaml
     program, annotated u...
-  embedPath: /videos/embed/92309d92-8cbf-4545-980c-209c96e42a79
-  thumbnailPath: /static/thumbnails/db29d3bf-784c-47f1-bf90-f13fd2a9d530.jpg
-  date: 2021-08-27T10:33:38.000Z
+  embed_path: /videos/embed/92309d92-8cbf-4545-980c-209c96e42a79
+  thumbnail_path: /static/thumbnails/db29d3bf-784c-47f1-bf90-f13fd2a9d530.jpg
+  published_at: 2021-08-27T10:33:38.000Z
+  updated_at: 2021-09-07T04:02:00.301Z
   language: English
   category: Science & Technology
 - name: Digodoc and Docs
@@ -115,15 +127,17 @@ watch:
     a graph of an opam switch, associating files, libraries and opam packages into
     a cyclic graph of inclusions and dependencies. We will then explain how we used
     that tool to buil...
-  embedPath: /videos/embed/db6ed2c4-e940-4d5f-82ee-d3d20eb4ceb7
-  thumbnailPath: /static/thumbnails/43a418d6-56ec-48f4-852b-0a18ec0789aa.jpg
-  date: 2021-08-27T12:09:56.000Z
+  embed_path: /videos/embed/db6ed2c4-e940-4d5f-82ee-d3d20eb4ceb7
+  thumbnail_path: /static/thumbnails/43a418d6-56ec-48f4-852b-0a18ec0789aa.jpg
+  published_at: 2021-08-27T12:09:56.000Z
+  updated_at: 2021-09-07T20:02:00.180Z
   language: English
   category: Science & Technology
 - name: Effective Concurrency through Algebraic Effects
-  embedPath: /videos/embed/e9f6c837-1435-4349-af0f-07d22d1c11ea
-  thumbnailPath: /static/thumbnails/1de58bd2-d2f9-428c-8b8c-97b48d6d2c7e.jpg
-  date: 2015-09-18T00:00:00.000Z
+  embed_path: /videos/embed/e9f6c837-1435-4349-af0f-07d22d1c11ea
+  thumbnail_path: /static/thumbnails/1de58bd2-d2f9-428c-8b8c-97b48d6d2c7e.jpg
+  published_at: 2015-09-18T00:00:00.000Z
+  updated_at: 2021-09-07T10:02:00.076Z
   language: English
   category: Science & Technology
 - name: Experiences with Effects in OCaml
@@ -131,9 +145,10 @@ watch:
     this talk, we report our experiences with effects, both from converting existing
     code, and from writing new code. Converting the Angstrom parser from a callback
     style to effects gr...
-  embedPath: /videos/embed/74ece0a8-380f-4e2a-bef5-c6bb9092be89
-  thumbnailPath: /static/thumbnails/d48bf7bb-8c46-4d49-a3a6-734bf339343b.jpg
-  date: 2021-08-27T14:41:07.000Z
+  embed_path: /videos/embed/74ece0a8-380f-4e2a-bef5-c6bb9092be89
+  thumbnail_path: /static/thumbnails/d48bf7bb-8c46-4d49-a3a6-734bf339343b.jpg
+  published_at: 2021-08-27T14:41:07.000Z
+  updated_at: 2021-09-08T05:02:00.187Z
   language: English
   category: Science & Technology
 - name: From 2n+1 to n
@@ -141,15 +156,17 @@ watch:
     around values which unify odd integers and aligned pointers. The last bit of a
     value distinguishes the two variants: zero indicates a pointer on the OCaml heap,
     while one encodes a ta..."
-  embedPath: /videos/embed/74b32dae-11c6-4713-be1b-946260196e50
-  thumbnailPath: /static/thumbnails/a2042ab9-9025-421a-9eae-176462ac594b.jpg
-  date: 2021-08-31T08:30:23.211Z
+  embed_path: /videos/embed/74b32dae-11c6-4713-be1b-946260196e50
+  thumbnail_path: /static/thumbnails/a2042ab9-9025-421a-9eae-176462ac594b.jpg
+  published_at: 2021-08-31T08:30:23.211Z
+  updated_at: 2021-09-06T14:02:00.190Z
   language: English
   category: Misc
 - name: Global Semantic Analysis on OCaml programs
-  embedPath: /videos/embed/51e4bdf0-50f7-4b13-8514-2d62b5341066
-  thumbnailPath: /static/thumbnails/8255d370-e621-44bc-b7c3-6dd39fab4d1d.jpg
-  date: 2015-09-18T00:00:00.000Z
+  embed_path: /videos/embed/51e4bdf0-50f7-4b13-8514-2d62b5341066
+  thumbnail_path: /static/thumbnails/8255d370-e621-44bc-b7c3-6dd39fab4d1d.jpg
+  published_at: 2015-09-18T00:00:00.000Z
+  updated_at: 2021-08-03T16:55:20.938Z
   language: English
   category: Science & Technology
 - name: 'GopCaml: A Structural Editor for OCaml'
@@ -157,15 +174,17 @@ watch:
     for OCaml. We will give a tour of the main plugin features, discussing the plugin\u2019s
     internal design and its integration with existing OCaml and GNU Emacs toolchains.\r\n\r\nKiran
     Gop..."
-  embedPath: /videos/embed/e0a6e6f2-0d40-4dfc-9308-001c8e0f64d6
-  thumbnailPath: /static/thumbnails/729cda51-abb3-4c8d-9d0e-b922e81be518.jpg
-  date: 2021-08-27T10:12:58.000Z
+  embed_path: /videos/embed/e0a6e6f2-0d40-4dfc-9308-001c8e0f64d6
+  thumbnail_path: /static/thumbnails/729cda51-abb3-4c8d-9d0e-b922e81be518.jpg
+  published_at: 2021-08-27T10:12:58.000Z
+  updated_at: 2021-09-07T15:02:00.164Z
   language: English
   category: Science & Technology
 - name: Inline Assembly in OCaml
-  embedPath: /videos/embed/632f520f-8f83-4b6f-89f1-5cde088436c7
-  thumbnailPath: /static/thumbnails/5d2f65d1-6129-4206-832b-c3d4bab410df.jpg
-  date: 2015-09-18T00:00:00.000Z
+  embed_path: /videos/embed/632f520f-8f83-4b6f-89f1-5cde088436c7
+  thumbnail_path: /static/thumbnails/5d2f65d1-6129-4206-832b-c3d4bab410df.jpg
+  published_at: 2015-09-18T00:00:00.000Z
+  updated_at: 2021-08-03T16:39:42.613Z
   language: English
   category: Science & Technology
 - name: Irmin v2
@@ -173,15 +192,17 @@ watch:
     the same design principles as Git. Existing Git users will find many familiar
     features: branching/merging, immutable causal history for all changes, and the
     ability to restore to an...'
-  embedPath: /videos/embed/53e497b0-898f-4c85-8da9-39f65ef0e0b1
-  thumbnailPath: /static/thumbnails/138e7c05-185b-4e54-95d0-d15018905a39.jpg
-  date: 2020-08-28T00:00:00.000Z
+  embed_path: /videos/embed/53e497b0-898f-4c85-8da9-39f65ef0e0b1
+  thumbnail_path: /static/thumbnails/138e7c05-185b-4e54-95d0-d15018905a39.jpg
+  published_at: 2020-08-28T00:00:00.000Z
+  updated_at: 2021-09-07T15:02:00.070Z
   language: Unknown
   category: Misc
 - name: Ketrew and Biokepi
-  embedPath: /videos/embed/f3dcee35-bc04-453a-ba35-7aec90599661
-  thumbnailPath: /static/thumbnails/0a36e8ce-c415-4191-ad5b-6ef2eb23db4e.jpg
-  date: 2015-09-18T00:00:00.000Z
+  embed_path: /videos/embed/f3dcee35-bc04-453a-ba35-7aec90599661
+  thumbnail_path: /static/thumbnails/0a36e8ce-c415-4191-ad5b-6ef2eb23db4e.jpg
+  published_at: 2015-09-18T00:00:00.000Z
+  updated_at: 2021-08-03T22:36:42.344Z
   language: English
   category: Science & Technology
 - name: Leveraging Formal Specifications to Generate Fuzzing Suites
@@ -189,9 +210,10 @@ watch:
     the semantics they want to check. They then write the code implementing these
     tests and find relevant test cases that expose possible misbehaviours.\r\n\r\nIn
     this work, we present a t..."
-  embedPath: /videos/embed/d9a36c9f-1611-42f9-8854-981b1e2d7d75
-  thumbnailPath: /static/thumbnails/e5d18bd4-b482-463c-80f8-35d9fbb46b23.jpg
-  date: 2021-08-27T10:40:06.000Z
+  embed_path: /videos/embed/d9a36c9f-1611-42f9-8854-981b1e2d7d75
+  thumbnail_path: /static/thumbnails/e5d18bd4-b482-463c-80f8-35d9fbb46b23.jpg
+  published_at: 2021-08-27T10:40:06.000Z
+  updated_at: 2021-09-07T04:02:00.442Z
   language: English
   category: Science & Technology
 - name: LexiFi Runtime Types
@@ -199,9 +221,10 @@ watch:
     safe and reliable software systems. The OCaml compiler relies on the invariants
     imposed by the type system to produce efficient and compact runtime data representations.
     Be...
-  embedPath: /videos/embed/cc7e3242-0bef-448a-aa13-8827bba933e3
-  thumbnailPath: /static/thumbnails/1d43d8b4-87d1-4398-b925-10a42460b8dc.jpg
-  date: 2020-08-28T00:00:00.000Z
+  embed_path: /videos/embed/cc7e3242-0bef-448a-aa13-8827bba933e3
+  thumbnail_path: /static/thumbnails/1d43d8b4-87d1-4398-b925-10a42460b8dc.jpg
+  published_at: 2020-08-28T00:00:00.000Z
+  updated_at: 2021-08-29T09:02:00.090Z
   language: Unknown
   category: Science & Technology
 - name: 'Love: a readable language interpreted by a blockchain'
@@ -209,9 +232,10 @@ watch:
     blockchain. It benefits from an OCaml-like syntax and a system-F inspired type
     system. Love has been used for deploying complex services such as games, ERC20s,
     atomic swaps, e...
-  embedPath: /videos/embed/d3b2b31e-1739-406e-8de7-d5f21bc01836
-  thumbnailPath: /static/thumbnails/93a6e9ac-2266-408a-81e7-1ebf239233f8.jpg
-  date: 2021-08-27T15:10:17.000Z
+  embed_path: /videos/embed/d3b2b31e-1739-406e-8de7-d5f21bc01836
+  thumbnail_path: /static/thumbnails/93a6e9ac-2266-408a-81e7-1ebf239233f8.jpg
+  published_at: 2021-08-27T15:10:17.000Z
+  updated_at: 2021-09-02T23:02:00.323Z
   language: English
   category: Science & Technology
 - name: 'OCaml Under The Hood: SmartPy'
@@ -219,9 +243,10 @@ watch:
     blockchain. It is an embedded EDSL in python to write contracts and their test
     scenarios. It includes an online IDE, a chain explorer, and a command-line interface.
     Python is us...
-  embedPath: /videos/embed/7446ad4d-4ae2-4e1a-bc38-af8f71e8ebd8
-  thumbnailPath: /static/thumbnails/e1ac5b07-3648-40c1-b62c-5e88471741dc.jpg
-  date: 2020-08-28T00:00:00.000Z
+  embed_path: /videos/embed/7446ad4d-4ae2-4e1a-bc38-af8f71e8ebd8
+  thumbnail_path: /static/thumbnails/e1ac5b07-3648-40c1-b62c-5e88471741dc.jpg
+  published_at: 2020-08-28T00:00:00.000Z
+  updated_at: 2021-05-19T17:08:00.226Z
   language: Unknown
   category: Misc
 - name: 'OCaml and Python: Getting the Best of Both Worlds'
@@ -229,9 +254,10 @@ watch:
     and services so that they can be accessed from Python. Our initial use case on
     the Python side consisted in Jupyter notebooks used to analyse various datasets,
     these datasets ...
-  embedPath: /videos/embed/9eafdb1e-9be9-4a52-98b4-f4696eda4c18
-  thumbnailPath: /static/thumbnails/53db83d1-0763-4dfa-a087-cce3cad1b581.jpg
-  date: 2021-08-27T10:16:54.000Z
+  embed_path: /videos/embed/9eafdb1e-9be9-4a52-98b4-f4696eda4c18
+  thumbnail_path: /static/thumbnails/53db83d1-0763-4dfa-a087-cce3cad1b581.jpg
+  published_at: 2021-08-27T10:16:54.000Z
+  updated_at: 2021-09-07T15:02:00.247Z
   language: English
   category: Science & Technology
 - name: 'OCaml-CI : A Zero-Configuration CI'
@@ -239,9 +265,10 @@ watch:
     from the project\u2019s opam and dune\nfiles to work out what to build, and uses
     caching\nto make builds fast. It automatically tests projects\nagainst multiple
     OCaml versions and OS platforms..."
-  embedPath: /videos/embed/0fee79e8-715a-400b-bfcc-34c3610f4890
-  thumbnailPath: /static/thumbnails/596f39a9-8654-4922-8bec-6e7ac5dcc319.jpg
-  date: 2020-08-28T00:00:00.000Z
+  embed_path: /videos/embed/0fee79e8-715a-400b-bfcc-34c3610f4890
+  thumbnail_path: /static/thumbnails/596f39a9-8654-4922-8bec-6e7ac5dcc319.jpg
+  published_at: 2020-08-28T00:00:00.000Z
+  updated_at: 2021-09-04T20:02:00.100Z
   language: English
   category: Misc
 - name: 'OCaml-CI : A Zero-Configuration CI'
@@ -249,9 +276,10 @@ watch:
     the project\u2019s opam and dune files to work out what to build, and uses caching
     to make builds fast. It automatically tests projects against multiple OCaml versions
     and OS platforms..."
-  embedPath: /videos/embed/da88d6ac-7ba1-4261-9308-d03fe21e35b9
-  thumbnailPath: /static/thumbnails/1c22a14e-f067-4d4e-8e26-027cc6d8a491.jpg
-  date: 2020-08-28T00:00:00.000Z
+  embed_path: /videos/embed/da88d6ac-7ba1-4261-9308-d03fe21e35b9
+  thumbnail_path: /static/thumbnails/1c22a14e-f067-4d4e-8e26-027cc6d8a491.jpg
+  published_at: 2020-08-28T00:00:00.000Z
+  updated_at: 2021-05-27T16:35:41.085Z
   language: English
   category: Science & Technology
 - name: 'Opam-bin: Binary Packages with Opam'
@@ -259,15 +287,17 @@ watch:
     Binary Opam packages on the fly, to speed-up reinstallation of pack- ages. opam-bin
     also creates Opam Repositories for these binary pack- ages, to make them easy
     to share with othe...
-  embedPath: /videos/embed/a889e4d3-0508-4734-b667-7060b0a253cd
-  thumbnailPath: /static/thumbnails/b2325a24-f068-473b-961e-a0b783ae5c39.jpg
-  date: 2021-08-27T15:01:40.000Z
+  embed_path: /videos/embed/a889e4d3-0508-4734-b667-7060b0a253cd
+  thumbnail_path: /static/thumbnails/b2325a24-f068-473b-961e-a0b783ae5c39.jpg
+  published_at: 2021-08-27T15:01:40.000Z
+  updated_at: 2021-09-08T06:02:00.094Z
   language: English
   category: Science & Technology
 - name: 'Operf: Benchmarking the OCaml Compiler'
-  embedPath: /videos/embed/5a4a6c12-3cb1-40d2-a663-25f294e12555
-  thumbnailPath: /static/thumbnails/c2b5c90a-9c9e-4058-94a1-15525795a01a.jpg
-  date: 2015-09-18T00:00:00.000Z
+  embed_path: /videos/embed/5a4a6c12-3cb1-40d2-a663-25f294e12555
+  thumbnail_path: /static/thumbnails/c2b5c90a-9c9e-4058-94a1-15525795a01a.jpg
+  published_at: 2015-09-18T00:00:00.000Z
+  updated_at: 2021-08-03T16:23:23.889Z
   language: English
   category: Science & Technology
 - name: 'Parafuzz: Coverage-guided Property Fuzzing for Multicore OCaml programs'
@@ -275,9 +305,10 @@ watch:
     OCaml programs. ParaFuzz builds on top of Crowbar which combines AFL-based grey
     box fuzzing with QuickCheck and extends it to handle parallelism.\r\n\r\nSumit
     Padhiyar\r\nIndian In..."
-  embedPath: /videos/embed/c0d591e0-91c9-4eaa-a4d7-c4f514de0a57
-  thumbnailPath: /static/thumbnails/b1a67c0a-2eb9-4c9d-97ce-b4dc039da59b.jpg
-  date: 2021-08-27T10:36:13.000Z
+  embed_path: /videos/embed/c0d591e0-91c9-4eaa-a4d7-c4f514de0a57
+  thumbnail_path: /static/thumbnails/b1a67c0a-2eb9-4c9d-97ce-b4dc039da59b.jpg
+  published_at: 2021-08-27T10:36:13.000Z
+  updated_at: 2021-09-07T04:02:00.349Z
   language: English
   category: Science & Technology
 - name: Parallelising your OCaml Code with Multicore OCaml
@@ -287,15 +318,17 @@ watch:
 
     With the availability of multicore variants of the recent OCaml versions (4.10
     and 4.11) that main...'
-  embedPath: /videos/embed/ce20839e-4bfc-4d74-925b-485a6b052ddf
-  thumbnailPath: /static/thumbnails/30bc6019-ecab-40e5-a7b6-c294ac9a7344.jpg
-  date: 2020-08-28T00:00:00.000Z
+  embed_path: /videos/embed/ce20839e-4bfc-4d74-925b-485a6b052ddf
+  thumbnail_path: /static/thumbnails/30bc6019-ecab-40e5-a7b6-c294ac9a7344.jpg
+  published_at: 2020-08-28T00:00:00.000Z
+  updated_at: 2021-09-05T03:02:00.936Z
   language: Unknown
   category: Misc
 - name: Persistent Networking with Irmin and MirageOS
-  embedPath: /videos/embed/97dd9634-28e4-4066-96e4-9c2036ee4bb2
-  thumbnailPath: /static/thumbnails/46ba8c5d-0f4a-427e-8e76-0c58cb0e70a7.jpg
-  date: 2015-09-18T00:00:00.000Z
+  embed_path: /videos/embed/97dd9634-28e4-4066-96e4-9c2036ee4bb2
+  thumbnail_path: /static/thumbnails/46ba8c5d-0f4a-427e-8e76-0c58cb0e70a7.jpg
+  published_at: 2015-09-18T00:00:00.000Z
+  updated_at: 2021-08-03T17:09:03.939Z
   language: English
   category: Science & Technology
 - name: Probabilistic resource limits using StatMemprof
@@ -303,9 +336,10 @@ watch:
     a probabilistic implementation of per-thread global memory limits, and per-thread
     allocation limits, for OCaml 4.12. Then, we will discuss the reasoning about programs
     in the pre...
-  embedPath: /videos/embed/bc297e85-82dd-4baf-8556-4a3a934978f9
-  thumbnailPath: /static/thumbnails/9b4dc06e-1d07-45b8-a21a-1e4f39897fef.jpg
-  date: 2021-08-27T11:08:12.000Z
+  embed_path: /videos/embed/bc297e85-82dd-4baf-8556-4a3a934978f9
+  thumbnail_path: /static/thumbnails/9b4dc06e-1d07-45b8-a21a-1e4f39897fef.jpg
+  published_at: 2021-08-27T11:08:12.000Z
+  updated_at: 2021-09-06T04:02:01.770Z
   language: English
   category: Science & Technology
 - name: Property-Based Testing for OCaml through Coq
@@ -313,9 +347,10 @@ watch:
     the power of QuickChick, a popular and mature testing plugin for the Coq proof
     assistant, by automatically constructing a extraction-based shim between OCaml
     and Coq. That...
-  embedPath: /videos/embed/9324fba4-2482-4bab-bfdd-b8881b3ed94a
-  thumbnailPath: /static/thumbnails/d7e22bba-cda1-4c2b-9368-9b2c1643e751.jpg
-  date: 2021-08-31T08:37:00.571Z
+  embed_path: /videos/embed/9324fba4-2482-4bab-bfdd-b8881b3ed94a
+  thumbnail_path: /static/thumbnails/d7e22bba-cda1-4c2b-9368-9b2c1643e751.jpg
+  published_at: 2021-08-31T08:37:00.571Z
+  updated_at: 2021-09-06T10:02:00.283Z
   language: English
   category: Misc
 - name: Safe Protocol Updates via Propositional Logic
@@ -323,9 +358,10 @@ watch:
     different executables, then changing that type or its serialization can result
     in versioning issues.\r\nOften such issues are resolved by either making the deserializer
     more permissiv..."
-  embedPath: /videos/embed/c6176f51-0277-46f0-937b-1e2721044492
-  thumbnailPath: /static/thumbnails/a89a3483-274a-44f1-9a38-c679f6b12196.jpg
-  date: 2021-08-31T08:34:54.707Z
+  embed_path: /videos/embed/c6176f51-0277-46f0-937b-1e2721044492
+  thumbnail_path: /static/thumbnails/a89a3483-274a-44f1-9a38-c679f6b12196.jpg
+  published_at: 2021-08-31T08:34:54.707Z
+  updated_at: 2021-09-04T14:02:00.088Z
   language: English
   category: Misc
 - name: 'Semgrep : a fast, lightweight, polyglot static analysis tool to find bugs'
@@ -333,21 +369,24 @@ watch:
     polyglot, open source static analysis tool to find bugs and enforce code standards.
     It is used internally by many companies including Dropbox and Snowflake. Semgrep
     is also now use..."
-  embedPath: /videos/embed/c0d07213-1426-46a1-98e0-0b0c4515c841
-  thumbnailPath: /static/thumbnails/2ab3961f-4e66-4ec9-b20e-72e25dfbebe4.jpg
-  date: 2021-08-31T08:41:15.492Z
+  embed_path: /videos/embed/c0d07213-1426-46a1-98e0-0b0c4515c841
+  thumbnail_path: /static/thumbnails/2ab3961f-4e66-4ec9-b20e-72e25dfbebe4.jpg
+  published_at: 2021-08-31T08:41:15.492Z
+  updated_at: 2021-09-05T16:02:01.373Z
   language: English
   category: Misc
 - name: Specialization of Generic Array Accesses After Inlining
-  embedPath: /videos/embed/80553916-b90a-4641-93c8-35b000df04c1
-  thumbnailPath: /static/thumbnails/1f81fbbf-6fb0-4047-93a1-57759431166a.jpg
-  date: 2015-09-18T00:00:00.000Z
+  embed_path: /videos/embed/80553916-b90a-4641-93c8-35b000df04c1
+  thumbnail_path: /static/thumbnails/1f81fbbf-6fb0-4047-93a1-57759431166a.jpg
+  published_at: 2015-09-18T00:00:00.000Z
+  updated_at: 2021-08-03T16:34:23.463Z
   language: Unknown
   category: Science & Technology
 - name: State of the OCaml Platform
-  embedPath: /videos/embed/390ce74c-f85f-477d-8f20-504437409add
-  thumbnailPath: /static/thumbnails/33258292-009b-42ee-83d3-9eb4bfb4e048.jpg
-  date: 2018-01-12T00:00:00.000Z
+  embed_path: /videos/embed/390ce74c-f85f-477d-8f20-504437409add
+  thumbnail_path: /static/thumbnails/33258292-009b-42ee-83d3-9eb4bfb4e048.jpg
+  published_at: 2018-01-12T00:00:00.000Z
+  updated_at: 2021-07-27T12:08:00.264Z
   language: English
   category: Science & Technology
 - name: State of the OCaml Platform 2020
@@ -359,9 +398,10 @@ watch:
     - Next Steps for the OCaml Platform
 
     - Plans for 2020-2021'
-  embedPath: /videos/embed/0e2070fd-798b-47f7-8e69-ef75e967e516
-  thumbnailPath: /static/thumbnails/4fd6a51f-686c-4f6f-8026-83692304b432.jpg
-  date: 2020-08-28T00:00:00.000Z
+  embed_path: /videos/embed/0e2070fd-798b-47f7-8e69-ef75e967e516
+  thumbnail_path: /static/thumbnails/4fd6a51f-686c-4f6f-8026-83692304b432.jpg
+  published_at: 2020-08-28T00:00:00.000Z
+  updated_at: 2021-08-30T08:02:00.086Z
   language: English
   category: Science & Technology
 - name: The ImpFS filesystem
@@ -369,9 +409,10 @@ watch:
     workshop. The presentation will cover a new OCaml filesystem, ImpFS, and the related
     libraries. The filesystem makes use of a B-tree library presented at OCaml\u201917,
     and a key-value ..."
-  embedPath: /videos/embed/28545b27-4637-47a5-8edd-6b904daef19c
-  thumbnailPath: /static/thumbnails/dde19660-653d-4dc3-9e81-54b2e3ab22a2.jpg
-  date: 2020-08-28T00:00:00.000Z
+  embed_path: /videos/embed/28545b27-4637-47a5-8edd-6b904daef19c
+  thumbnail_path: /static/thumbnails/dde19660-653d-4dc3-9e81-54b2e3ab22a2.jpg
+  published_at: 2020-08-28T00:00:00.000Z
+  updated_at: 2021-09-04T20:02:00.472Z
   language: Unknown
   category: Misc
 - name: The OCaml Platform 1.0 - Reason ML
@@ -383,21 +424,24 @@ watch:
     - but how do we get there?
 
     This video will ...'
-  embedPath: /videos/embed/bd9a8e54-6ca5-4036-a08c-6a47cee6619e
-  thumbnailPath: /static/thumbnails/ddc1e6fb-9999-4e79-b458-31c7e3ec1108.jpg
-  date: 2018-12-11T00:00:00.000Z
+  embed_path: /videos/embed/bd9a8e54-6ca5-4036-a08c-6a47cee6619e
+  thumbnail_path: /static/thumbnails/ddc1e6fb-9999-4e79-b458-31c7e3ec1108.jpg
+  published_at: 2018-12-11T00:00:00.000Z
+  updated_at: 2021-09-03T14:02:00.094Z
   language: English
   category: Science & Technology
 - name: The State of OCaml
-  embedPath: /videos/embed/60a2ecfb-86ea-4881-a279-0a928452a3c3
-  thumbnailPath: /static/thumbnails/a5e5f630-2df9-4691-8ddf-a8137001ab4c.jpg
-  date: 2015-09-18T00:00:00.000Z
+  embed_path: /videos/embed/60a2ecfb-86ea-4881-a279-0a928452a3c3
+  thumbnail_path: /static/thumbnails/a5e5f630-2df9-4691-8ddf-a8137001ab4c.jpg
+  published_at: 2015-09-18T00:00:00.000Z
+  updated_at: 2021-09-02T10:02:00.083Z
   language: English
   category: Science & Technology
 - name: The State of the OCaml Platform
-  embedPath: /videos/embed/32475a83-b455-455b-937f-28e7185f4fc2
-  thumbnailPath: /static/thumbnails/7eb8af05-a6d5-4a88-89f3-146673a87cf0.jpg
-  date: 2015-09-18T00:00:00.000Z
+  embed_path: /videos/embed/32475a83-b455-455b-937f-28e7185f4fc2
+  thumbnail_path: /static/thumbnails/7eb8af05-a6d5-4a88-89f3-146673a87cf0.jpg
+  published_at: 2015-09-18T00:00:00.000Z
+  updated_at: 2021-08-03T16:47:54.414Z
   language: English
   category: Science & Technology
 - name: The final pieces of the OCaml documentation puzzle
@@ -405,15 +449,17 @@ watch:
     The ever-evolving OCaml module system is extremely rich and can include complex
     set of inter-dependencies that are both difficult to compute and to render in
     a concise document. It...'
-  embedPath: /videos/embed/2acebff9-25fa-4733-83cc-620a65b12251
-  thumbnailPath: /static/thumbnails/c877a501-c705-44f7-8826-e7ce846a5e42.jpg
-  date: 2020-08-28T00:00:00.000Z
+  embed_path: /videos/embed/2acebff9-25fa-4733-83cc-620a65b12251
+  thumbnail_path: /static/thumbnails/c877a501-c705-44f7-8826-e7ce846a5e42.jpg
+  published_at: 2020-08-28T00:00:00.000Z
+  updated_at: 2021-09-05T03:02:00.455Z
   language: English
   category: Misc
 - name: Towards A Debugger for Native Code OCaml
-  embedPath: /videos/embed/b76f3301-261d-44f3-97ec-1910b45f6969
-  thumbnailPath: /static/thumbnails/93ea327e-5e8b-4844-b237-75719a7256b9.jpg
-  date: 2015-09-18T00:00:00.000Z
+  embed_path: /videos/embed/b76f3301-261d-44f3-97ec-1910b45f6969
+  thumbnail_path: /static/thumbnails/93ea327e-5e8b-4844-b237-75719a7256b9.jpg
+  published_at: 2015-09-18T00:00:00.000Z
+  updated_at: 2021-08-03T16:20:17.728Z
   language: English
   category: Science & Technology
 - name: Types in Amber
@@ -421,9 +467,10 @@ watch:
     the size of data needed by nodes running its protocol. Nodes communicate in a
     format automatically derived from type definitions in OCaml source files. As the
     Coda software ev...
-  embedPath: /videos/embed/99b3dc75-9f93-4677-9f8b-076546725512
-  thumbnailPath: /static/thumbnails/acd50ed1-43cf-45fd-a55e-9c40a6bf58ba.jpg
-  date: 2020-08-28T00:00:00.000Z
+  embed_path: /videos/embed/99b3dc75-9f93-4677-9f8b-076546725512
+  thumbnail_path: /static/thumbnails/acd50ed1-43cf-45fd-a55e-9c40a6bf58ba.jpg
+  published_at: 2020-08-28T00:00:00.000Z
+  updated_at: 2021-08-29T09:02:00.201Z
   language: Unknown
   category: Misc
 - name: Wibbily Wobbly Timey Camly
@@ -431,8 +478,9 @@ watch:
     due to myriad standards and complexity of time zone definitions. This also complicates
     scheduling across multiple time zones especially when one takes Daylight Saving
     Time int...
-  embedPath: /videos/embed/ec641446-823b-40ec-a207-85157a18f88e
-  thumbnailPath: /static/thumbnails/2300474a-7615-4c92-9489-9ff5117d8bc7.jpg
-  date: 2021-08-27T10:37:18.000Z
+  embed_path: /videos/embed/ec641446-823b-40ec-a207-85157a18f88e
+  thumbnail_path: /static/thumbnails/2300474a-7615-4c92-9489-9ff5117d8bc7.jpg
+  published_at: 2021-08-27T10:37:18.000Z
+  updated_at: 2021-09-07T04:02:00.396Z
   language: English
   category: Science & Technology

--- a/data/watch.yml
+++ b/data/watch.yml
@@ -1,14 +1,79 @@
 watch:
-- name: 'Semgrep : a fast, lightweight, polyglot static analysis tool to find bugs'
-  description: "Semgrep, which stands for \u201Csemantic grep,\u201D is a fast, lightweight,
-    polyglot, open source static analysis tool to find bugs and enforce code standards.
-    It is used internally by many companies including Dropbox and Snowflake. Semgrep
-    is also now use..."
-  embedPath: /videos/embed/c0d07213-1426-46a1-98e0-0b0c4515c841
-  thumbnailPath: /static/thumbnails/2ab3961f-4e66-4ec9-b20e-72e25dfbebe4.jpg
-  date: 2021-08-31T08:41:15.492Z
+- name: '25 Years of OCaml: Xavier Leroy'
+  description: Professor Xavier Leroy -- the primary original author and leader of
+    the OCaml project -- reflects on 25 years of the OCaml language at his OCaml Workshop
+    2021 keynote speech.
+  embedPath: /videos/embed/e1ee0fc0-50ef-4a1c-894a-17df181424cb
+  thumbnailPath: /static/thumbnails/94ead657-79a0-4c10-8435-9e13906a6c44.jpg
+  date: 2021-08-27T13:23:10.199Z
   language: English
+  category: Science & Technology
+- name: A Declarative Syntax Definition for OCaml
+  description: In this talk, we present our work on a syntax definition for the OCaml
+    language in the syntax definition formalism SDF3. SDF3 supports the high-level
+    definition of concrete and abstract syntax through declarative disambiguation
+    and definition of c...
+  embedPath: /videos/embed/a5b86864-8e43-4138-b6d6-ed48d2d4b63d
+  thumbnailPath: /static/thumbnails/92c0a0e3-5326-42aa-86a3-6adb3927e111.jpg
+  date: 2020-08-28T00:00:00.000Z
+  language: Unknown
   category: Misc
+- name: A Multiverse of Glorious Documentation
+  description: This talk describes the process of generating documentation for every
+    version of every package that can be built from the opam repository, and how it
+    is presented as a single coherent website that is continuously updated as new
+    packages are releas...
+  embedPath: /videos/embed/9bb452d6-1829-4dac-a6a2-46b31050c931
+  thumbnailPath: /static/thumbnails/6a0a8291-4626-4820-8071-904b3c508345.jpg
+  date: 2021-08-27T11:23:36.000Z
+  language: English
+  category: Science & Technology
+- name: A Simple State-Machine Framework for Property-Based Testing in OCaml
+  description: "Since their inception, state-machine frameworks have proven their
+    worth by finding defects in everything from the underlying AUTOSAR components
+    of Volvo cars to digital invoicing systems. These case studies were carried out
+    with Erlang\u2019s commercia..."
+  embedPath: /videos/embed/08b429ea-2eb8-427d-a625-5495f4ee0fef
+  thumbnailPath: /static/thumbnails/316ddad9-dbc3-4d46-9f43-5da72689e93b.jpg
+  date: 2020-08-28T00:00:00.000Z
+  language: Unknown
+  category: Misc
+- name: A review of the growth of the OCaml community
+  embedPath: /videos/embed/f9d0b637-8aec-4bff-8c32-cd16b58023b6
+  thumbnailPath: /static/thumbnails/e573402b-1350-4aa7-a9ba-0e1c51198fb4.jpg
+  date: 2015-09-18T00:00:00.000Z
+  language: Unknown
+  category: Science & Technology
+- name: 'AD-OCaml: Algorithmic Differentiation for OCaml'
+  description: AD-OCaml is a library framework for calculating mathematically exact
+    derivatives and deep power series approximations of almost arbitrary OCaml programs
+    via algorithmic differentiation. Unlike similar frameworks, this includes programs
+    with side e...
+  embedPath: /videos/embed/c9e85690-732f-4b03-836f-2ee0fd8f0658
+  thumbnailPath: /static/thumbnails/eb972fd2-668e-4998-a798-e9fbdcadba20.jpg
+  date: 2020-08-28T00:00:00.000Z
+  language: Unknown
+  category: Misc
+- name: 'API migration: compare transformed'
+  description: In this talk we describe our experience in using an automatic API-migration
+    strategy dedicated at changing the signatures of OCaml functions, using the Rotor
+    refactoring tool for OCaml. We perform a case study on open source Jane Street
+    libraries ...
+  embedPath: /videos/embed/c46b925b-bd77-404f-ac5d-5dab65047529
+  thumbnailPath: /static/thumbnails/eef64419-3c34-4c15-9419-edcbc455e54d.jpg
+  date: 2020-08-28T00:00:00.000Z
+  language: Unknown
+  category: Misc
+- name: Adapting the OCaml ecosystem for Multicore OCaml
+  description: "OCaml 5.0 with support for shared-memory parallelism being around
+    the corner, there\u2019s increasing interest in the community to port existing
+    libraries to Multicore. This talk will take the attendees through what the arrival
+    of Multicore means to th..."
+  embedPath: /videos/embed/629b89a8-bbd5-490d-98b0-d0c740912b02
+  thumbnailPath: /static/thumbnails/41212c84-36d6-44fa-b884-2ced79505929.jpg
+  date: 2021-08-27T10:18:38.000Z
+  language: English
+  category: Science & Technology
 - name: Binary Analysis Platform
   description: We present Binary Analysis Platform (BAP), a representation-agnostic
     program analysis framework for binaries that can leverage existing tools, libraries,
@@ -19,6 +84,230 @@ watch:
   date: 2021-08-31T08:39:55.774Z
   language: English
   category: Misc
+- name: Continuous Benchmarking for OCaml Projects
+  description: "Regular CI systems are optimised for workloads that do not require
+    stable performance over time. This makes them unsuitable for running performance
+    benchmarks.\r\n\r\ncurrent-bench provides a predictable environment for performance
+    benchmarks and a UI..."
+  embedPath: /videos/embed/1c994370-1aaa-4db6-b901-d762786e4904
+  thumbnailPath: /static/thumbnails/33ab36c3-3650-4c13-9fea-9b5907cf8c0f.jpg
+  date: 2021-08-27T11:20:09.000Z
+  language: English
+  category: Science & Technology
+- name: 'Core Time stamp counter: A fast high resolution time source'
+  embedPath: /videos/embed/75b4d60f-3e37-40bd-b025-f39dcce0c42c
+  thumbnailPath: /static/thumbnails/43248673-6478-4e96-b8ac-cd415d85569b.jpg
+  date: 2015-09-18T00:00:00.000Z
+  language: English
+  category: Science & Technology
+- name: Deductive Verification of Realistic OCaml Code
+  description: We present the formal verification of a subset of the Set module from
+    the OCaml standard library. The proof is conducted using Cameleer, a new tool
+    for the deductive verification of OCaml code. Cameleer takes as input an OCaml
+    program, annotated u...
+  embedPath: /videos/embed/92309d92-8cbf-4545-980c-209c96e42a79
+  thumbnailPath: /static/thumbnails/db29d3bf-784c-47f1-bf90-f13fd2a9d530.jpg
+  date: 2021-08-27T10:33:38.000Z
+  language: English
+  category: Science & Technology
+- name: Digodoc and Docs
+  description: In this talk, we will introduce a new tool called digodoc, that builds
+    a graph of an opam switch, associating files, libraries and opam packages into
+    a cyclic graph of inclusions and dependencies. We will then explain how we used
+    that tool to buil...
+  embedPath: /videos/embed/db6ed2c4-e940-4d5f-82ee-d3d20eb4ceb7
+  thumbnailPath: /static/thumbnails/43a418d6-56ec-48f4-852b-0a18ec0789aa.jpg
+  date: 2021-08-27T12:09:56.000Z
+  language: English
+  category: Science & Technology
+- name: Effective Concurrency through Algebraic Effects
+  embedPath: /videos/embed/e9f6c837-1435-4349-af0f-07d22d1c11ea
+  thumbnailPath: /static/thumbnails/1de58bd2-d2f9-428c-8b8c-97b48d6d2c7e.jpg
+  date: 2015-09-18T00:00:00.000Z
+  language: English
+  category: Science & Technology
+- name: Experiences with Effects in OCaml
+  description: The multicore branch of OCaml adds support for effect handlers. In
+    this talk, we report our experiences with effects, both from converting existing
+    code, and from writing new code. Converting the Angstrom parser from a callback
+    style to effects gr...
+  embedPath: /videos/embed/74ece0a8-380f-4e2a-bef5-c6bb9092be89
+  thumbnailPath: /static/thumbnails/d48bf7bb-8c46-4d49-a3a6-734bf339343b.jpg
+  date: 2021-08-27T14:41:07.000Z
+  language: English
+  category: Science & Technology
+- name: From 2n+1 to n
+  description: "\r\nOCaml relies on a type-agnostic object representation centred
+    around values which unify odd integers and aligned pointers. The last bit of a
+    value distinguishes the two variants: zero indicates a pointer on the OCaml heap,
+    while one encodes a ta..."
+  embedPath: /videos/embed/74b32dae-11c6-4713-be1b-946260196e50
+  thumbnailPath: /static/thumbnails/a2042ab9-9025-421a-9eae-176462ac594b.jpg
+  date: 2021-08-31T08:30:23.211Z
+  language: English
+  category: Misc
+- name: Global Semantic Analysis on OCaml programs
+  embedPath: /videos/embed/51e4bdf0-50f7-4b13-8514-2d62b5341066
+  thumbnailPath: /static/thumbnails/8255d370-e621-44bc-b7c3-6dd39fab4d1d.jpg
+  date: 2015-09-18T00:00:00.000Z
+  language: English
+  category: Science & Technology
+- name: 'GopCaml: A Structural Editor for OCaml'
+  description: "This talk presents GopCaml-mode, the first structural editing plugin
+    for OCaml. We will give a tour of the main plugin features, discussing the plugin\u2019s
+    internal design and its integration with existing OCaml and GNU Emacs toolchains.\r\n\r\nKiran
+    Gop..."
+  embedPath: /videos/embed/e0a6e6f2-0d40-4dfc-9308-001c8e0f64d6
+  thumbnailPath: /static/thumbnails/729cda51-abb3-4c8d-9d0e-b922e81be518.jpg
+  date: 2021-08-27T10:12:58.000Z
+  language: English
+  category: Science & Technology
+- name: Inline Assembly in OCaml
+  embedPath: /videos/embed/632f520f-8f83-4b6f-89f1-5cde088436c7
+  thumbnailPath: /static/thumbnails/5d2f65d1-6129-4206-832b-c3d4bab410df.jpg
+  date: 2015-09-18T00:00:00.000Z
+  language: English
+  category: Science & Technology
+- name: Irmin v2
+  description: 'Irmin is an OCaml library for building distributed databases with
+    the same design principles as Git. Existing Git users will find many familiar
+    features: branching/merging, immutable causal history for all changes, and the
+    ability to restore to an...'
+  embedPath: /videos/embed/53e497b0-898f-4c85-8da9-39f65ef0e0b1
+  thumbnailPath: /static/thumbnails/138e7c05-185b-4e54-95d0-d15018905a39.jpg
+  date: 2020-08-28T00:00:00.000Z
+  language: Unknown
+  category: Misc
+- name: Ketrew and Biokepi
+  embedPath: /videos/embed/f3dcee35-bc04-453a-ba35-7aec90599661
+  thumbnailPath: /static/thumbnails/0a36e8ce-c415-4191-ad5b-6ef2eb23db4e.jpg
+  date: 2015-09-18T00:00:00.000Z
+  language: English
+  category: Science & Technology
+- name: Leveraging Formal Specifications to Generate Fuzzing Suites
+  description: "When testing a library, developers typically first have to capture
+    the semantics they want to check. They then write the code implementing these
+    tests and find relevant test cases that expose possible misbehaviours.\r\n\r\nIn
+    this work, we present a t..."
+  embedPath: /videos/embed/d9a36c9f-1611-42f9-8854-981b1e2d7d75
+  thumbnailPath: /static/thumbnails/e5d18bd4-b482-463c-80f8-35d9fbb46b23.jpg
+  date: 2021-08-27T10:40:06.000Z
+  language: English
+  category: Science & Technology
+- name: LexiFi Runtime Types
+  description: OCaml programmers make deliberate use of abstract data types for composing
+    safe and reliable software systems. The OCaml compiler relies on the invariants
+    imposed by the type system to produce efficient and compact runtime data representations.
+    Be...
+  embedPath: /videos/embed/cc7e3242-0bef-448a-aa13-8827bba933e3
+  thumbnailPath: /static/thumbnails/1d43d8b4-87d1-4398-b925-10a42460b8dc.jpg
+  date: 2020-08-28T00:00:00.000Z
+  language: Unknown
+  category: Science & Technology
+- name: 'Love: a readable language interpreted by a blockchain'
+  description: We present Love, a smart contract language embedded in the Dune Network
+    blockchain. It benefits from an OCaml-like syntax and a system-F inspired type
+    system. Love has been used for deploying complex services such as games, ERC20s,
+    atomic swaps, e...
+  embedPath: /videos/embed/d3b2b31e-1739-406e-8de7-d5f21bc01836
+  thumbnailPath: /static/thumbnails/93a6e9ac-2266-408a-81e7-1ebf239233f8.jpg
+  date: 2021-08-27T15:10:17.000Z
+  language: English
+  category: Science & Technology
+- name: 'OCaml Under The Hood: SmartPy'
+  description: SmartPy is a complete system to develop smart-contracts for the Tezos
+    blockchain. It is an embedded EDSL in python to write contracts and their test
+    scenarios. It includes an online IDE, a chain explorer, and a command-line interface.
+    Python is us...
+  embedPath: /videos/embed/7446ad4d-4ae2-4e1a-bc38-af8f71e8ebd8
+  thumbnailPath: /static/thumbnails/e1ac5b07-3648-40c1-b62c-5e88471741dc.jpg
+  date: 2020-08-28T00:00:00.000Z
+  language: Unknown
+  category: Misc
+- name: 'OCaml and Python: Getting the Best of Both Worlds'
+  description: In this talk we present how we expose a wide variety of OCaml libraries
+    and services so that they can be accessed from Python. Our initial use case on
+    the Python side consisted in Jupyter notebooks used to analyse various datasets,
+    these datasets ...
+  embedPath: /videos/embed/9eafdb1e-9be9-4a52-98b4-f4696eda4c18
+  thumbnailPath: /static/thumbnails/53db83d1-0763-4dfa-a087-cce3cad1b581.jpg
+  date: 2021-08-27T10:16:54.000Z
+  language: English
+  category: Science & Technology
+- name: 'OCaml-CI : A Zero-Configuration CI'
+  description: "OCaml-CI\n\nis a CI service for OCaml projects. It\nuses metadata
+    from the project\u2019s opam and dune\nfiles to work out what to build, and uses
+    caching\nto make builds fast. It automatically tests projects\nagainst multiple
+    OCaml versions and OS platforms..."
+  embedPath: /videos/embed/0fee79e8-715a-400b-bfcc-34c3610f4890
+  thumbnailPath: /static/thumbnails/596f39a9-8654-4922-8bec-6e7ac5dcc319.jpg
+  date: 2020-08-28T00:00:00.000Z
+  language: English
+  category: Misc
+- name: 'OCaml-CI : A Zero-Configuration CI'
+  description: "OCaml-CI1 is a CI service for OCaml projects. It uses metadata from
+    the project\u2019s opam and dune files to work out what to build, and uses caching
+    to make builds fast. It automatically tests projects against multiple OCaml versions
+    and OS platforms..."
+  embedPath: /videos/embed/da88d6ac-7ba1-4261-9308-d03fe21e35b9
+  thumbnailPath: /static/thumbnails/1c22a14e-f067-4d4e-8e26-027cc6d8a491.jpg
+  date: 2020-08-28T00:00:00.000Z
+  language: English
+  category: Science & Technology
+- name: 'Opam-bin: Binary Packages with Opam'
+  description: In this talk, we will present opam-bin, an Opam plugin that builds
+    Binary Opam packages on the fly, to speed-up reinstallation of pack- ages. opam-bin
+    also creates Opam Repositories for these binary pack- ages, to make them easy
+    to share with othe...
+  embedPath: /videos/embed/a889e4d3-0508-4734-b667-7060b0a253cd
+  thumbnailPath: /static/thumbnails/b2325a24-f068-473b-961e-a0b783ae5c39.jpg
+  date: 2021-08-27T15:01:40.000Z
+  language: English
+  category: Science & Technology
+- name: 'Operf: Benchmarking the OCaml Compiler'
+  embedPath: /videos/embed/5a4a6c12-3cb1-40d2-a663-25f294e12555
+  thumbnailPath: /static/thumbnails/c2b5c90a-9c9e-4058-94a1-15525795a01a.jpg
+  date: 2015-09-18T00:00:00.000Z
+  language: English
+  category: Science & Technology
+- name: 'Parafuzz: Coverage-guided Property Fuzzing for Multicore OCaml programs'
+  description: "We develop ParaFuzz, an input and concurrency fuzzing tool for Multicore
+    OCaml programs. ParaFuzz builds on top of Crowbar which combines AFL-based grey
+    box fuzzing with QuickCheck and extends it to handle parallelism.\r\n\r\nSumit
+    Padhiyar\r\nIndian In..."
+  embedPath: /videos/embed/c0d591e0-91c9-4eaa-a4d7-c4f514de0a57
+  thumbnailPath: /static/thumbnails/b1a67c0a-2eb9-4c9d-97ce-b4dc039da59b.jpg
+  date: 2021-08-27T10:36:13.000Z
+  language: English
+  category: Science & Technology
+- name: Parallelising your OCaml Code with Multicore OCaml
+  description: 'Slides, speaker notes and runnable examples mentioned in this talk
+    are available at: https://github.com/ocaml-multicore/ocaml2020-workshop-parallel
+
+
+    With the availability of multicore variants of the recent OCaml versions (4.10
+    and 4.11) that main...'
+  embedPath: /videos/embed/ce20839e-4bfc-4d74-925b-485a6b052ddf
+  thumbnailPath: /static/thumbnails/30bc6019-ecab-40e5-a7b6-c294ac9a7344.jpg
+  date: 2020-08-28T00:00:00.000Z
+  language: Unknown
+  category: Misc
+- name: Persistent Networking with Irmin and MirageOS
+  embedPath: /videos/embed/97dd9634-28e4-4066-96e4-9c2036ee4bb2
+  thumbnailPath: /static/thumbnails/46ba8c5d-0f4a-427e-8e76-0c58cb0e70a7.jpg
+  date: 2015-09-18T00:00:00.000Z
+  language: English
+  category: Science & Technology
+- name: Probabilistic resource limits using StatMemprof
+  description: The goal of this talk is two-fold. First, we present memprof-limits,
+    a probabilistic implementation of per-thread global memory limits, and per-thread
+    allocation limits, for OCaml 4.12. Then, we will discuss the reasoning about programs
+    in the pre...
+  embedPath: /videos/embed/bc297e85-82dd-4baf-8556-4a3a934978f9
+  thumbnailPath: /static/thumbnails/9b4dc06e-1d07-45b8-a21a-1e4f39897fef.jpg
+  date: 2021-08-27T11:08:12.000Z
+  language: English
+  category: Science & Technology
 - name: Property-Based Testing for OCaml through Coq
   description: We will present a property-based testing framework for OCaml that leverages
     the power of QuickChick, a popular and mature testing plugin for the Coq proof
@@ -39,163 +328,26 @@ watch:
   date: 2021-08-31T08:34:54.707Z
   language: English
   category: Misc
-- name: From 2n+1 to n
-  description: "\r\nOCaml relies on a type-agnostic object representation centred
-    around values which unify odd integers and aligned pointers. The last bit of a
-    value distinguishes the two variants: zero indicates a pointer on the OCaml heap,
-    while one encodes a ta..."
-  embedPath: /videos/embed/74b32dae-11c6-4713-be1b-946260196e50
-  thumbnailPath: /static/thumbnails/a2042ab9-9025-421a-9eae-176462ac594b.jpg
-  date: 2021-08-31T08:30:23.211Z
+- name: 'Semgrep : a fast, lightweight, polyglot static analysis tool to find bugs'
+  description: "Semgrep, which stands for \u201Csemantic grep,\u201D is a fast, lightweight,
+    polyglot, open source static analysis tool to find bugs and enforce code standards.
+    It is used internally by many companies including Dropbox and Snowflake. Semgrep
+    is also now use..."
+  embedPath: /videos/embed/c0d07213-1426-46a1-98e0-0b0c4515c841
+  thumbnailPath: /static/thumbnails/2ab3961f-4e66-4ec9-b20e-72e25dfbebe4.jpg
+  date: 2021-08-31T08:41:15.492Z
   language: English
   category: Misc
-- name: 'Love: a readable language interpreted by a blockchain'
-  description: We present Love, a smart contract language embedded in the Dune Network
-    blockchain. It benefits from an OCaml-like syntax and a system-F inspired type
-    system. Love has been used for deploying complex services such as games, ERC20s,
-    atomic swaps, e...
-  embedPath: /videos/embed/d3b2b31e-1739-406e-8de7-d5f21bc01836
-  thumbnailPath: /static/thumbnails/93a6e9ac-2266-408a-81e7-1ebf239233f8.jpg
-  date: 2021-08-27T15:10:17.000Z
-  language: English
+- name: Specialization of Generic Array Accesses After Inlining
+  embedPath: /videos/embed/80553916-b90a-4641-93c8-35b000df04c1
+  thumbnailPath: /static/thumbnails/1f81fbbf-6fb0-4047-93a1-57759431166a.jpg
+  date: 2015-09-18T00:00:00.000Z
+  language: Unknown
   category: Science & Technology
-- name: 'Opam-bin: Binary Packages with Opam'
-  description: In this talk, we will present opam-bin, an Opam plugin that builds
-    Binary Opam packages on the fly, to speed-up reinstallation of pack- ages. opam-bin
-    also creates Opam Repositories for these binary pack- ages, to make them easy
-    to share with othe...
-  embedPath: /videos/embed/a889e4d3-0508-4734-b667-7060b0a253cd
-  thumbnailPath: /static/thumbnails/b2325a24-f068-473b-961e-a0b783ae5c39.jpg
-  date: 2021-08-27T15:01:40.000Z
-  language: English
-  category: Science & Technology
-- name: Experiences with Effects in OCaml
-  description: The multicore branch of OCaml adds support for effect handlers. In
-    this talk, we report our experiences with effects, both from converting existing
-    code, and from writing new code. Converting the Angstrom parser from a callback
-    style to effects gr...
-  embedPath: /videos/embed/74ece0a8-380f-4e2a-bef5-c6bb9092be89
-  thumbnailPath: /static/thumbnails/d48bf7bb-8c46-4d49-a3a6-734bf339343b.jpg
-  date: 2021-08-27T14:41:07.000Z
-  language: English
-  category: Science & Technology
-- name: '25 Years of OCaml: Xavier Leroy'
-  description: Professor Xavier Leroy -- the primary original author and leader of
-    the OCaml project -- reflects on 25 years of the OCaml language at his OCaml Workshop
-    2021 keynote speech.
-  embedPath: /videos/embed/e1ee0fc0-50ef-4a1c-894a-17df181424cb
-  thumbnailPath: /static/thumbnails/94ead657-79a0-4c10-8435-9e13906a6c44.jpg
-  date: 2021-08-27T13:23:10.199Z
-  language: English
-  category: Science & Technology
-- name: Digodoc and Docs
-  description: In this talk, we will introduce a new tool called digodoc, that builds
-    a graph of an opam switch, associating files, libraries and opam packages into
-    a cyclic graph of inclusions and dependencies. We will then explain how we used
-    that tool to buil...
-  embedPath: /videos/embed/db6ed2c4-e940-4d5f-82ee-d3d20eb4ceb7
-  thumbnailPath: /static/thumbnails/43a418d6-56ec-48f4-852b-0a18ec0789aa.jpg
-  date: 2021-08-27T12:09:56.000Z
-  language: English
-  category: Science & Technology
-- name: A Multiverse of Glorious Documentation
-  description: This talk describes the process of generating documentation for every
-    version of every package that can be built from the opam repository, and how it
-    is presented as a single coherent website that is continuously updated as new
-    packages are releas...
-  embedPath: /videos/embed/9bb452d6-1829-4dac-a6a2-46b31050c931
-  thumbnailPath: /static/thumbnails/6a0a8291-4626-4820-8071-904b3c508345.jpg
-  date: 2021-08-27T11:23:36.000Z
-  language: English
-  category: Science & Technology
-- name: Continuous Benchmarking for OCaml Projects
-  description: "Regular CI systems are optimised for workloads that do not require
-    stable performance over time. This makes them unsuitable for running performance
-    benchmarks.\r\n\r\ncurrent-bench provides a predictable environment for performance
-    benchmarks and a UI..."
-  embedPath: /videos/embed/1c994370-1aaa-4db6-b901-d762786e4904
-  thumbnailPath: /static/thumbnails/33ab36c3-3650-4c13-9fea-9b5907cf8c0f.jpg
-  date: 2021-08-27T11:20:09.000Z
-  language: English
-  category: Science & Technology
-- name: Probabilistic resource limits using StatMemprof
-  description: The goal of this talk is two-fold. First, we present memprof-limits,
-    a probabilistic implementation of per-thread global memory limits, and per-thread
-    allocation limits, for OCaml 4.12. Then, we will discuss the reasoning about programs
-    in the pre...
-  embedPath: /videos/embed/bc297e85-82dd-4baf-8556-4a3a934978f9
-  thumbnailPath: /static/thumbnails/9b4dc06e-1d07-45b8-a21a-1e4f39897fef.jpg
-  date: 2021-08-27T11:08:12.000Z
-  language: English
-  category: Science & Technology
-- name: Leveraging Formal Specifications to Generate Fuzzing Suites
-  description: "When testing a library, developers typically first have to capture
-    the semantics they want to check. They then write the code implementing these
-    tests and find relevant test cases that expose possible misbehaviours.\r\n\r\nIn
-    this work, we present a t..."
-  embedPath: /videos/embed/d9a36c9f-1611-42f9-8854-981b1e2d7d75
-  thumbnailPath: /static/thumbnails/e5d18bd4-b482-463c-80f8-35d9fbb46b23.jpg
-  date: 2021-08-27T10:40:06.000Z
-  language: English
-  category: Science & Technology
-- name: Wibbily Wobbly Timey Camly
-  description: Time handling is commonly considered a difficult problem by programmers
-    due to myriad standards and complexity of time zone definitions. This also complicates
-    scheduling across multiple time zones especially when one takes Daylight Saving
-    Time int...
-  embedPath: /videos/embed/ec641446-823b-40ec-a207-85157a18f88e
-  thumbnailPath: /static/thumbnails/2300474a-7615-4c92-9489-9ff5117d8bc7.jpg
-  date: 2021-08-27T10:37:18.000Z
-  language: English
-  category: Science & Technology
-- name: 'Parafuzz: Coverage-guided Property Fuzzing for Multicore OCaml programs'
-  description: "We develop ParaFuzz, an input and concurrency fuzzing tool for Multicore
-    OCaml programs. ParaFuzz builds on top of Crowbar which combines AFL-based grey
-    box fuzzing with QuickCheck and extends it to handle parallelism.\r\n\r\nSumit
-    Padhiyar\r\nIndian In..."
-  embedPath: /videos/embed/c0d591e0-91c9-4eaa-a4d7-c4f514de0a57
-  thumbnailPath: /static/thumbnails/b1a67c0a-2eb9-4c9d-97ce-b4dc039da59b.jpg
-  date: 2021-08-27T10:36:13.000Z
-  language: English
-  category: Science & Technology
-- name: Deductive Verification of Realistic OCaml Code
-  description: We present the formal verification of a subset of the Set module from
-    the OCaml standard library. The proof is conducted using Cameleer, a new tool
-    for the deductive verification of OCaml code. Cameleer takes as input an OCaml
-    program, annotated u...
-  embedPath: /videos/embed/92309d92-8cbf-4545-980c-209c96e42a79
-  thumbnailPath: /static/thumbnails/db29d3bf-784c-47f1-bf90-f13fd2a9d530.jpg
-  date: 2021-08-27T10:33:38.000Z
-  language: English
-  category: Science & Technology
-- name: Adapting the OCaml ecosystem for Multicore OCaml
-  description: "OCaml 5.0 with support for shared-memory parallelism being around
-    the corner, there\u2019s increasing interest in the community to port existing
-    libraries to Multicore. This talk will take the attendees through what the arrival
-    of Multicore means to th..."
-  embedPath: /videos/embed/629b89a8-bbd5-490d-98b0-d0c740912b02
-  thumbnailPath: /static/thumbnails/41212c84-36d6-44fa-b884-2ced79505929.jpg
-  date: 2021-08-27T10:18:38.000Z
-  language: English
-  category: Science & Technology
-- name: 'OCaml and Python: Getting the Best of Both Worlds'
-  description: In this talk we present how we expose a wide variety of OCaml libraries
-    and services so that they can be accessed from Python. Our initial use case on
-    the Python side consisted in Jupyter notebooks used to analyse various datasets,
-    these datasets ...
-  embedPath: /videos/embed/9eafdb1e-9be9-4a52-98b4-f4696eda4c18
-  thumbnailPath: /static/thumbnails/53db83d1-0763-4dfa-a087-cce3cad1b581.jpg
-  date: 2021-08-27T10:16:54.000Z
-  language: English
-  category: Science & Technology
-- name: 'GopCaml: A Structural Editor for OCaml'
-  description: "This talk presents GopCaml-mode, the first structural editing plugin
-    for OCaml. We will give a tour of the main plugin features, discussing the plugin\u2019s
-    internal design and its integration with existing OCaml and GNU Emacs toolchains.\r\n\r\nKiran
-    Gop..."
-  embedPath: /videos/embed/e0a6e6f2-0d40-4dfc-9308-001c8e0f64d6
-  thumbnailPath: /static/thumbnails/729cda51-abb3-4c8d-9d0e-b922e81be518.jpg
-  date: 2021-08-27T10:12:58.000Z
+- name: State of the OCaml Platform
+  embedPath: /videos/embed/390ce74c-f85f-477d-8f20-504437409add
+  thumbnailPath: /static/thumbnails/33258292-009b-42ee-83d3-9eb4bfb4e048.jpg
+  date: 2018-01-12T00:00:00.000Z
   language: English
   category: Science & Technology
 - name: State of the OCaml Platform 2020
@@ -212,58 +364,6 @@ watch:
   date: 2020-08-28T00:00:00.000Z
   language: English
   category: Science & Technology
-- name: 'OCaml-CI : A Zero-Configuration CI'
-  description: "OCaml-CI\n\nis a CI service for OCaml projects. It\nuses metadata
-    from the project\u2019s opam and dune\nfiles to work out what to build, and uses
-    caching\nto make builds fast. It automatically tests projects\nagainst multiple
-    OCaml versions and OS platforms..."
-  embedPath: /videos/embed/0fee79e8-715a-400b-bfcc-34c3610f4890
-  thumbnailPath: /static/thumbnails/596f39a9-8654-4922-8bec-6e7ac5dcc319.jpg
-  date: 2020-08-28T00:00:00.000Z
-  language: English
-  category: Misc
-- name: The final pieces of the OCaml documentation puzzle
-  description: 'Rendering OCaml document is widely known as a very difficult task:
-    The ever-evolving OCaml module system is extremely rich and can include complex
-    set of inter-dependencies that are both difficult to compute and to render in
-    a concise document. It...'
-  embedPath: /videos/embed/2acebff9-25fa-4733-83cc-620a65b12251
-  thumbnailPath: /static/thumbnails/c877a501-c705-44f7-8826-e7ce846a5e42.jpg
-  date: 2020-08-28T00:00:00.000Z
-  language: English
-  category: Misc
-- name: 'API migration: compare transformed'
-  description: In this talk we describe our experience in using an automatic API-migration
-    strategy dedicated at changing the signatures of OCaml functions, using the Rotor
-    refactoring tool for OCaml. We perform a case study on open source Jane Street
-    libraries ...
-  embedPath: /videos/embed/c46b925b-bd77-404f-ac5d-5dab65047529
-  thumbnailPath: /static/thumbnails/eef64419-3c34-4c15-9419-edcbc455e54d.jpg
-  date: 2020-08-28T00:00:00.000Z
-  language: Unknown
-  category: Misc
-- name: Parallelising your OCaml Code with Multicore OCaml
-  description: 'Slides, speaker notes and runnable examples mentioned in this talk
-    are available at: https://github.com/ocaml-multicore/ocaml2020-workshop-parallel
-
-
-    With the availability of multicore variants of the recent OCaml versions (4.10
-    and 4.11) that main...'
-  embedPath: /videos/embed/ce20839e-4bfc-4d74-925b-485a6b052ddf
-  thumbnailPath: /static/thumbnails/30bc6019-ecab-40e5-a7b6-c294ac9a7344.jpg
-  date: 2020-08-28T00:00:00.000Z
-  language: Unknown
-  category: Misc
-- name: A Simple State-Machine Framework for Property-Based Testing in OCaml
-  description: "Since their inception, state-machine frameworks have proven their
-    worth by finding defects in everything from the underlying AUTOSAR components
-    of Volvo cars to digital invoicing systems. These case studies were carried out
-    with Erlang\u2019s commercia..."
-  embedPath: /videos/embed/08b429ea-2eb8-427d-a625-5495f4ee0fef
-  thumbnailPath: /static/thumbnails/316ddad9-dbc3-4d46-9f43-5da72689e93b.jpg
-  date: 2020-08-28T00:00:00.000Z
-  language: Unknown
-  category: Misc
 - name: The ImpFS filesystem
   description: "This proposal describes a presentation to be given at the OCaml\u201920
     workshop. The presentation will cover a new OCaml filesystem, ImpFS, and the related
@@ -274,76 +374,6 @@ watch:
   date: 2020-08-28T00:00:00.000Z
   language: Unknown
   category: Misc
-- name: Irmin v2
-  description: 'Irmin is an OCaml library for building distributed databases with
-    the same design principles as Git. Existing Git users will find many familiar
-    features: branching/merging, immutable causal history for all changes, and the
-    ability to restore to an...'
-  embedPath: /videos/embed/53e497b0-898f-4c85-8da9-39f65ef0e0b1
-  thumbnailPath: /static/thumbnails/138e7c05-185b-4e54-95d0-d15018905a39.jpg
-  date: 2020-08-28T00:00:00.000Z
-  language: Unknown
-  category: Misc
-- name: 'AD-OCaml: Algorithmic Differentiation for OCaml'
-  description: AD-OCaml is a library framework for calculating mathematically exact
-    derivatives and deep power series approximations of almost arbitrary OCaml programs
-    via algorithmic differentiation. Unlike similar frameworks, this includes programs
-    with side e...
-  embedPath: /videos/embed/c9e85690-732f-4b03-836f-2ee0fd8f0658
-  thumbnailPath: /static/thumbnails/eb972fd2-668e-4998-a798-e9fbdcadba20.jpg
-  date: 2020-08-28T00:00:00.000Z
-  language: Unknown
-  category: Misc
-- name: 'OCaml Under The Hood: SmartPy'
-  description: SmartPy is a complete system to develop smart-contracts for the Tezos
-    blockchain. It is an embedded EDSL in python to write contracts and their test
-    scenarios. It includes an online IDE, a chain explorer, and a command-line interface.
-    Python is us...
-  embedPath: /videos/embed/7446ad4d-4ae2-4e1a-bc38-af8f71e8ebd8
-  thumbnailPath: /static/thumbnails/e1ac5b07-3648-40c1-b62c-5e88471741dc.jpg
-  date: 2020-08-28T00:00:00.000Z
-  language: Unknown
-  category: Misc
-- name: A Declarative Syntax Definition for OCaml
-  description: In this talk, we present our work on a syntax definition for the OCaml
-    language in the syntax definition formalism SDF3. SDF3 supports the high-level
-    definition of concrete and abstract syntax through declarative disambiguation
-    and definition of c...
-  embedPath: /videos/embed/a5b86864-8e43-4138-b6d6-ed48d2d4b63d
-  thumbnailPath: /static/thumbnails/92c0a0e3-5326-42aa-86a3-6adb3927e111.jpg
-  date: 2020-08-28T00:00:00.000Z
-  language: Unknown
-  category: Misc
-- name: LexiFi Runtime Types
-  description: OCaml programmers make deliberate use of abstract data types for composing
-    safe and reliable software systems. The OCaml compiler relies on the invariants
-    imposed by the type system to produce efficient and compact runtime data representations.
-    Be...
-  embedPath: /videos/embed/cc7e3242-0bef-448a-aa13-8827bba933e3
-  thumbnailPath: /static/thumbnails/1d43d8b4-87d1-4398-b925-10a42460b8dc.jpg
-  date: 2020-08-28T00:00:00.000Z
-  language: Unknown
-  category: Science & Technology
-- name: Types in Amber
-  description: Coda is a new cryptocurrency that uses zk-SNARKs to dramatically reduce
-    the size of data needed by nodes running its protocol. Nodes communicate in a
-    format automatically derived from type definitions in OCaml source files. As the
-    Coda software ev...
-  embedPath: /videos/embed/99b3dc75-9f93-4677-9f8b-076546725512
-  thumbnailPath: /static/thumbnails/acd50ed1-43cf-45fd-a55e-9c40a6bf58ba.jpg
-  date: 2020-08-28T00:00:00.000Z
-  language: Unknown
-  category: Misc
-- name: 'OCaml-CI : A Zero-Configuration CI'
-  description: "OCaml-CI1 is a CI service for OCaml projects. It uses metadata from
-    the project\u2019s opam and dune files to work out what to build, and uses caching
-    to make builds fast. It automatically tests projects against multiple OCaml versions
-    and OS platforms..."
-  embedPath: /videos/embed/da88d6ac-7ba1-4261-9308-d03fe21e35b9
-  thumbnailPath: /static/thumbnails/1c22a14e-f067-4d4e-8e26-027cc6d8a491.jpg
-  date: 2020-08-28T00:00:00.000Z
-  language: English
-  category: Science & Technology
 - name: The OCaml Platform 1.0 - Reason ML
   description: 'Presented by Anil Madhavapeddy (@avsm)
 
@@ -358,42 +388,6 @@ watch:
   date: 2018-12-11T00:00:00.000Z
   language: English
   category: Science & Technology
-- name: State of the OCaml Platform
-  embedPath: /videos/embed/390ce74c-f85f-477d-8f20-504437409add
-  thumbnailPath: /static/thumbnails/33258292-009b-42ee-83d3-9eb4bfb4e048.jpg
-  date: 2018-01-12T00:00:00.000Z
-  language: English
-  category: Science & Technology
-- name: Towards A Debugger for Native Code OCaml
-  embedPath: /videos/embed/b76f3301-261d-44f3-97ec-1910b45f6969
-  thumbnailPath: /static/thumbnails/93ea327e-5e8b-4844-b237-75719a7256b9.jpg
-  date: 2015-09-18T00:00:00.000Z
-  language: English
-  category: Science & Technology
-- name: 'Operf: Benchmarking the OCaml Compiler'
-  embedPath: /videos/embed/5a4a6c12-3cb1-40d2-a663-25f294e12555
-  thumbnailPath: /static/thumbnails/c2b5c90a-9c9e-4058-94a1-15525795a01a.jpg
-  date: 2015-09-18T00:00:00.000Z
-  language: English
-  category: Science & Technology
-- name: 'Core Time stamp counter: A fast high resolution time source'
-  embedPath: /videos/embed/75b4d60f-3e37-40bd-b025-f39dcce0c42c
-  thumbnailPath: /static/thumbnails/43248673-6478-4e96-b8ac-cd415d85569b.jpg
-  date: 2015-09-18T00:00:00.000Z
-  language: English
-  category: Science & Technology
-- name: Specialization of Generic Array Accesses After Inlining
-  embedPath: /videos/embed/80553916-b90a-4641-93c8-35b000df04c1
-  thumbnailPath: /static/thumbnails/1f81fbbf-6fb0-4047-93a1-57759431166a.jpg
-  date: 2015-09-18T00:00:00.000Z
-  language: Unknown
-  category: Science & Technology
-- name: Inline Assembly in OCaml
-  embedPath: /videos/embed/632f520f-8f83-4b6f-89f1-5cde088436c7
-  thumbnailPath: /static/thumbnails/5d2f65d1-6129-4206-832b-c3d4bab410df.jpg
-  date: 2015-09-18T00:00:00.000Z
-  language: English
-  category: Science & Technology
 - name: The State of OCaml
   embedPath: /videos/embed/60a2ecfb-86ea-4881-a279-0a928452a3c3
   thumbnailPath: /static/thumbnails/a5e5f630-2df9-4691-8ddf-a8137001ab4c.jpg
@@ -406,33 +400,39 @@ watch:
   date: 2015-09-18T00:00:00.000Z
   language: English
   category: Science & Technology
-- name: Global Semantic Analysis on OCaml programs
-  embedPath: /videos/embed/51e4bdf0-50f7-4b13-8514-2d62b5341066
-  thumbnailPath: /static/thumbnails/8255d370-e621-44bc-b7c3-6dd39fab4d1d.jpg
+- name: The final pieces of the OCaml documentation puzzle
+  description: 'Rendering OCaml document is widely known as a very difficult task:
+    The ever-evolving OCaml module system is extremely rich and can include complex
+    set of inter-dependencies that are both difficult to compute and to render in
+    a concise document. It...'
+  embedPath: /videos/embed/2acebff9-25fa-4733-83cc-620a65b12251
+  thumbnailPath: /static/thumbnails/c877a501-c705-44f7-8826-e7ce846a5e42.jpg
+  date: 2020-08-28T00:00:00.000Z
+  language: English
+  category: Misc
+- name: Towards A Debugger for Native Code OCaml
+  embedPath: /videos/embed/b76f3301-261d-44f3-97ec-1910b45f6969
+  thumbnailPath: /static/thumbnails/93ea327e-5e8b-4844-b237-75719a7256b9.jpg
   date: 2015-09-18T00:00:00.000Z
   language: English
   category: Science & Technology
-- name: Effective Concurrency through Algebraic Effects
-  embedPath: /videos/embed/e9f6c837-1435-4349-af0f-07d22d1c11ea
-  thumbnailPath: /static/thumbnails/1de58bd2-d2f9-428c-8b8c-97b48d6d2c7e.jpg
-  date: 2015-09-18T00:00:00.000Z
-  language: English
-  category: Science & Technology
-- name: A review of the growth of the OCaml community
-  embedPath: /videos/embed/f9d0b637-8aec-4bff-8c32-cd16b58023b6
-  thumbnailPath: /static/thumbnails/e573402b-1350-4aa7-a9ba-0e1c51198fb4.jpg
-  date: 2015-09-18T00:00:00.000Z
+- name: Types in Amber
+  description: Coda is a new cryptocurrency that uses zk-SNARKs to dramatically reduce
+    the size of data needed by nodes running its protocol. Nodes communicate in a
+    format automatically derived from type definitions in OCaml source files. As the
+    Coda software ev...
+  embedPath: /videos/embed/99b3dc75-9f93-4677-9f8b-076546725512
+  thumbnailPath: /static/thumbnails/acd50ed1-43cf-45fd-a55e-9c40a6bf58ba.jpg
+  date: 2020-08-28T00:00:00.000Z
   language: Unknown
-  category: Science & Technology
-- name: Persistent Networking with Irmin and MirageOS
-  embedPath: /videos/embed/97dd9634-28e4-4066-96e4-9c2036ee4bb2
-  thumbnailPath: /static/thumbnails/46ba8c5d-0f4a-427e-8e76-0c58cb0e70a7.jpg
-  date: 2015-09-18T00:00:00.000Z
-  language: English
-  category: Science & Technology
-- name: Ketrew and Biokepi
-  embedPath: /videos/embed/f3dcee35-bc04-453a-ba35-7aec90599661
-  thumbnailPath: /static/thumbnails/0a36e8ce-c415-4191-ad5b-6ef2eb23db4e.jpg
-  date: 2015-09-18T00:00:00.000Z
+  category: Misc
+- name: Wibbily Wobbly Timey Camly
+  description: Time handling is commonly considered a difficult problem by programmers
+    due to myriad standards and complexity of time zone definitions. This also complicates
+    scheduling across multiple time zones especially when one takes Daylight Saving
+    Time int...
+  embedPath: /videos/embed/ec641446-823b-40ec-a207-85157a18f88e
+  thumbnailPath: /static/thumbnails/2300474a-7615-4c92-9489-9ff5117d8bc7.jpg
+  date: 2021-08-27T10:37:18.000Z
   language: English
   category: Science & Technology

--- a/data/watch.yml
+++ b/data/watch.yml
@@ -1,151 +1,438 @@
 watch:
-  - name: State of the OCaml Platform 2020
-    description: ! 'This talk covers:
-      - Integrated Development Environments
-      - Next Steps for the OCaml Platform
-      - Plans for 2020-2021'
-    embedPath: /videos/embed/0e2070fd-798b-47f7-8e69-ef75e967e516
-    thumbnailPath: /static/thumbnails/4fd6a51f-686c-4f6f-8026-83692304b432.jpg
-    year: 2020
-    language: English
-    category: Science & Technology
-  - name: ! 'OCaml-CI : A Zero-Configuration CI'
-    description: ! "OCaml-CI\n\nis a CI service for OCaml projects. It\nuses metadata
-      from the project\u2019s opam and dune\nfiles to work out what to build, and uses
-      caching\nto make builds fast. It automatically tests projects\nagainst multiple
-      OCaml versions and OS platforms..."
-    embedPath: /videos/embed/0fee79e8-715a-400b-bfcc-34c3610f4890
-    thumbnailPath: /static/thumbnails/596f39a9-8654-4922-8bec-6e7ac5dcc319.jpg
-    year: 2020
-    language: English
-    category: Misc
-  - name: The final pieces of the OCaml documentation puzzle
-    description: ! 'Rendering OCaml document is widely known as a very difficult task:
-      The ever-evolving OCaml module system is extremely rich and can include complex
-      set of inter-dependencies that are both difficult to compute and to render in
-      a concise document. It...'
-    embedPath: /videos/embed/2acebff9-25fa-4733-83cc-620a65b12251
-    thumbnailPath: /static/thumbnails/c877a501-c705-44f7-8826-e7ce846a5e42.jpg
-    year: 2020
-    language: English
-    category: Misc
-  - name: ! 'API migration: compare transformed'
-    description: In this talk we describe our experience in using an automatic API-migration
-      strategy dedicated at changing the signatures of OCaml functions, using the Rotor
-      refactoring tool for OCaml. We perform a case study on open source Jane Street
-      libraries ...
-    embedPath: /videos/embed/c46b925b-bd77-404f-ac5d-5dab65047529
-    thumbnailPath: /static/thumbnails/eef64419-3c34-4c15-9419-edcbc455e54d.jpg
-    year: 2020
-    language: Unknown
-    category: Misc
-  - name: Parallelising your OCaml Code with Multicore OCaml
-    description: ! 'Slides, speaker notes and runnable examples mentioned in this talk
-      are available at: https://github.com/ocaml-multicore/ocaml2020-workshop-parallel
-      With the availability of multicore variants of the recent OCaml versions (4.10
-      and 4.11) that main...'
-    embedPath: /videos/embed/ce20839e-4bfc-4d74-925b-485a6b052ddf
-    thumbnailPath: /static/thumbnails/30bc6019-ecab-40e5-a7b6-c294ac9a7344.jpg
-    year: 2020
-    language: Unknown
-    category: Misc
-  - name: A Simple State-Machine Framework for Property-Based Testing in OCaml
-    description: ! "Since their inception, state-machine frameworks have proven their
-      worth by finding defects in everything from the underlying AUTOSAR components
-      of Volvo cars to digital invoicing systems. These case studies were carried out
-      with Erlang\u2019s commercia..."
-    embedPath: /videos/embed/08b429ea-2eb8-427d-a625-5495f4ee0fef
-    thumbnailPath: /static/thumbnails/316ddad9-dbc3-4d46-9f43-5da72689e93b.jpg
-    year: 2020
-    language: Unknown
-    category: Misc
-  - name: The ImpFS filesystem
-    description: ! "This proposal describes a presentation to be given at the OCaml\u201920
-      workshop. The presentation will cover a new OCaml filesystem, ImpFS, and the related
-      libraries. The filesystem makes use of a B-tree library presented at OCaml\u201917,
-      and a key-value ..."
-    embedPath: /videos/embed/28545b27-4637-47a5-8edd-6b904daef19c
-    thumbnailPath: /static/thumbnails/dde19660-653d-4dc3-9e81-54b2e3ab22a2.jpg
-    year: 2020
-    language: Unknown
-    category: Misc
-  - name: Irmin v2
-    description: ! 'Irmin is an OCaml library for building distributed databases with
-      the same design principles as Git. Existing Git users will find many familiar
-      features: branching/merging, immutable causal history for all changes, and the
-      ability to restore to an...'
-    embedPath: /videos/embed/53e497b0-898f-4c85-8da9-39f65ef0e0b1
-    thumbnailPath: /static/thumbnails/138e7c05-185b-4e54-95d0-d15018905a39.jpg
-    year: 2020
-    language: Unknown
-    category: Misc
-  - name: ! 'AD-OCaml: Algorithmic Differentiation for OCaml'
-    description: AD-OCaml is a library framework for calculating mathematically exact
-      derivatives and deep power series approximations of almost arbitrary OCaml programs
-      via algorithmic differentiation. Unlike similar frameworks, this includes programs
-      with side e...
-    embedPath: /videos/embed/c9e85690-732f-4b03-836f-2ee0fd8f0658
-    thumbnailPath: /static/thumbnails/eb972fd2-668e-4998-a798-e9fbdcadba20.jpg
-    year: 2020
-    language: Unknown
-    category: Misc
-  - name: ! 'OCaml Under The Hood: SmartPy'
-    description: SmartPy is a complete system to develop smart-contracts for the Tezos
-      blockchain. It is an embedded EDSL in python to write contracts and their test
-      scenarios. It includes an online IDE, a chain explorer, and a command-line interface.
-      Python is us...
-    embedPath: /videos/embed/7446ad4d-4ae2-4e1a-bc38-af8f71e8ebd8
-    thumbnailPath: /static/thumbnails/e1ac5b07-3648-40c1-b62c-5e88471741dc.jpg
-    year: 2020
-    language: Unknown
-    category: Misc
-  - name: A Declarative Syntax Definition for OCaml
-    description: In this talk, we present our work on a syntax definition for the OCaml
-      language in the syntax definition formalism SDF3. SDF3 supports the high-level
-      definition of concrete and abstract syntax through declarative disambiguation
-      and definition of c...
-    embedPath: /videos/embed/a5b86864-8e43-4138-b6d6-ed48d2d4b63d
-    thumbnailPath: /static/thumbnails/92c0a0e3-5326-42aa-86a3-6adb3927e111.jpg
-    year: 2020
-    language: Unknown
-    category: Misc
-  - name: LexiFi Runtime Types
-    description: OCaml programmers make deliberate use of abstract data types for composing
-      safe and reliable software systems. The OCaml compiler relies on the invariants
-      imposed by the type system to produce efficient and compact runtime data representations.
-      Be...
-    embedPath: /videos/embed/cc7e3242-0bef-448a-aa13-8827bba933e3
-    thumbnailPath: /static/thumbnails/1d43d8b4-87d1-4398-b925-10a42460b8dc.jpg
-    year: 2020
-    language: Unknown
-    category: Science & Technology
-  - name: Types in Amber
-    description: Coda is a new cryptocurrency that uses zk-SNARKs to dramatically reduce
-      the size of data needed by nodes running its protocol. Nodes communicate in a
-      format automatically derived from type definitions in OCaml source files. As the
-      Coda software ev...
-    embedPath: /videos/embed/99b3dc75-9f93-4677-9f8b-076546725512
-    thumbnailPath: /static/thumbnails/acd50ed1-43cf-45fd-a55e-9c40a6bf58ba.jpg
-    year: 2020
-    language: Unknown
-    category: Misc
-  - name: ! 'OCaml-CI : A Zero-Configuration CI'
-    description: ! "OCaml-CI1 is a CI service for OCaml projects. It uses metadata from
-      the project\u2019s opam and dune files to work out what to build, and uses caching
-      to make builds fast. It automatically tests projects against multiple OCaml versions
-      and OS platforms..."
-    embedPath: /videos/embed/da88d6ac-7ba1-4261-9308-d03fe21e35b9
-    thumbnailPath: /static/thumbnails/1c22a14e-f067-4d4e-8e26-027cc6d8a491.jpg
-    year: 2020
-    language: English
-    category: Science & Technology
-  - name: History and key features of OCaml Language
-    description: The OCaml programming language is a member of the ML language family
-      pioneered by Robin Milner. An important feature of OCaml is that it reconciles
-      the conciseness and flexibility of untyped programming languages (like Python,
-      for example) with th...
-    embedPath: /videos/embed/64da4a9f-777e-478a-bd94-94ea8b57e570
-    thumbnailPath: /static/thumbnails/878b7470-9eea-4321-9276-3f888571c4e4.jpg
-    year: 2020
-    language: English
-    category: Education
+- name: 'Semgrep : a fast, lightweight, polyglot static analysis tool to find bugs'
+  description: "Semgrep, which stands for \u201Csemantic grep,\u201D is a fast, lightweight,
+    polyglot, open source static analysis tool to find bugs and enforce code standards.
+    It is used internally by many companies including Dropbox and Snowflake. Semgrep
+    is also now use..."
+  embedPath: /videos/embed/c0d07213-1426-46a1-98e0-0b0c4515c841
+  thumbnailPath: /static/thumbnails/2ab3961f-4e66-4ec9-b20e-72e25dfbebe4.jpg
+  date: 2021-08-31T08:41:15.492Z
+  language: English
+  category: Misc
+- name: Binary Analysis Platform
+  description: We present Binary Analysis Platform (BAP), a representation-agnostic
+    program analysis framework for binaries that can leverage existing tools, libraries,
+    and frameworks, no matter which intermediate representation (IR) they use. In
+    BAP, a new IR c...
+  embedPath: /videos/embed/8dc2d8d3-c140-4c3d-a8fe-a6fcf6fba988
+  thumbnailPath: /static/thumbnails/390cd7dd-4578-4162-bae0-6c218cb5ebde.jpg
+  date: 2021-08-31T08:39:55.774Z
+  language: English
+  category: Misc
+- name: Property-Based Testing for OCaml through Coq
+  description: We will present a property-based testing framework for OCaml that leverages
+    the power of QuickChick, a popular and mature testing plugin for the Coq proof
+    assistant, by automatically constructing a extraction-based shim between OCaml
+    and Coq. That...
+  embedPath: /videos/embed/9324fba4-2482-4bab-bfdd-b8881b3ed94a
+  thumbnailPath: /static/thumbnails/d7e22bba-cda1-4c2b-9368-9b2c1643e751.jpg
+  date: 2021-08-31T08:37:00.571Z
+  language: English
+  category: Misc
+- name: Safe Protocol Updates via Propositional Logic
+  description: "If values of a given type are stored on disk, or are sent between
+    different executables, then changing that type or its serialization can result
+    in versioning issues.\r\nOften such issues are resolved by either making the deserializer
+    more permissiv..."
+  embedPath: /videos/embed/c6176f51-0277-46f0-937b-1e2721044492
+  thumbnailPath: /static/thumbnails/a89a3483-274a-44f1-9a38-c679f6b12196.jpg
+  date: 2021-08-31T08:34:54.707Z
+  language: English
+  category: Misc
+- name: From 2n+1 to n
+  description: "\r\nOCaml relies on a type-agnostic object representation centred
+    around values which unify odd integers and aligned pointers. The last bit of a
+    value distinguishes the two variants: zero indicates a pointer on the OCaml heap,
+    while one encodes a ta..."
+  embedPath: /videos/embed/74b32dae-11c6-4713-be1b-946260196e50
+  thumbnailPath: /static/thumbnails/a2042ab9-9025-421a-9eae-176462ac594b.jpg
+  date: 2021-08-31T08:30:23.211Z
+  language: English
+  category: Misc
+- name: 'Love: a readable language interpreted by a blockchain'
+  description: We present Love, a smart contract language embedded in the Dune Network
+    blockchain. It benefits from an OCaml-like syntax and a system-F inspired type
+    system. Love has been used for deploying complex services such as games, ERC20s,
+    atomic swaps, e...
+  embedPath: /videos/embed/d3b2b31e-1739-406e-8de7-d5f21bc01836
+  thumbnailPath: /static/thumbnails/93a6e9ac-2266-408a-81e7-1ebf239233f8.jpg
+  date: 2021-08-27T15:10:17.000Z
+  language: English
+  category: Science & Technology
+- name: 'Opam-bin: Binary Packages with Opam'
+  description: In this talk, we will present opam-bin, an Opam plugin that builds
+    Binary Opam packages on the fly, to speed-up reinstallation of pack- ages. opam-bin
+    also creates Opam Repositories for these binary pack- ages, to make them easy
+    to share with othe...
+  embedPath: /videos/embed/a889e4d3-0508-4734-b667-7060b0a253cd
+  thumbnailPath: /static/thumbnails/b2325a24-f068-473b-961e-a0b783ae5c39.jpg
+  date: 2021-08-27T15:01:40.000Z
+  language: English
+  category: Science & Technology
+- name: Experiences with Effects in OCaml
+  description: The multicore branch of OCaml adds support for effect handlers. In
+    this talk, we report our experiences with effects, both from converting existing
+    code, and from writing new code. Converting the Angstrom parser from a callback
+    style to effects gr...
+  embedPath: /videos/embed/74ece0a8-380f-4e2a-bef5-c6bb9092be89
+  thumbnailPath: /static/thumbnails/d48bf7bb-8c46-4d49-a3a6-734bf339343b.jpg
+  date: 2021-08-27T14:41:07.000Z
+  language: English
+  category: Science & Technology
+- name: '25 Years of OCaml: Xavier Leroy'
+  description: Professor Xavier Leroy -- the primary original author and leader of
+    the OCaml project -- reflects on 25 years of the OCaml language at his OCaml Workshop
+    2021 keynote speech.
+  embedPath: /videos/embed/e1ee0fc0-50ef-4a1c-894a-17df181424cb
+  thumbnailPath: /static/thumbnails/94ead657-79a0-4c10-8435-9e13906a6c44.jpg
+  date: 2021-08-27T13:23:10.199Z
+  language: English
+  category: Science & Technology
+- name: Digodoc and Docs
+  description: In this talk, we will introduce a new tool called digodoc, that builds
+    a graph of an opam switch, associating files, libraries and opam packages into
+    a cyclic graph of inclusions and dependencies. We will then explain how we used
+    that tool to buil...
+  embedPath: /videos/embed/db6ed2c4-e940-4d5f-82ee-d3d20eb4ceb7
+  thumbnailPath: /static/thumbnails/43a418d6-56ec-48f4-852b-0a18ec0789aa.jpg
+  date: 2021-08-27T12:09:56.000Z
+  language: English
+  category: Science & Technology
+- name: A Multiverse of Glorious Documentation
+  description: This talk describes the process of generating documentation for every
+    version of every package that can be built from the opam repository, and how it
+    is presented as a single coherent website that is continuously updated as new
+    packages are releas...
+  embedPath: /videos/embed/9bb452d6-1829-4dac-a6a2-46b31050c931
+  thumbnailPath: /static/thumbnails/6a0a8291-4626-4820-8071-904b3c508345.jpg
+  date: 2021-08-27T11:23:36.000Z
+  language: English
+  category: Science & Technology
+- name: Continuous Benchmarking for OCaml Projects
+  description: "Regular CI systems are optimised for workloads that do not require
+    stable performance over time. This makes them unsuitable for running performance
+    benchmarks.\r\n\r\ncurrent-bench provides a predictable environment for performance
+    benchmarks and a UI..."
+  embedPath: /videos/embed/1c994370-1aaa-4db6-b901-d762786e4904
+  thumbnailPath: /static/thumbnails/33ab36c3-3650-4c13-9fea-9b5907cf8c0f.jpg
+  date: 2021-08-27T11:20:09.000Z
+  language: English
+  category: Science & Technology
+- name: Probabilistic resource limits using StatMemprof
+  description: The goal of this talk is two-fold. First, we present memprof-limits,
+    a probabilistic implementation of per-thread global memory limits, and per-thread
+    allocation limits, for OCaml 4.12. Then, we will discuss the reasoning about programs
+    in the pre...
+  embedPath: /videos/embed/bc297e85-82dd-4baf-8556-4a3a934978f9
+  thumbnailPath: /static/thumbnails/9b4dc06e-1d07-45b8-a21a-1e4f39897fef.jpg
+  date: 2021-08-27T11:08:12.000Z
+  language: English
+  category: Science & Technology
+- name: Leveraging Formal Specifications to Generate Fuzzing Suites
+  description: "When testing a library, developers typically first have to capture
+    the semantics they want to check. They then write the code implementing these
+    tests and find relevant test cases that expose possible misbehaviours.\r\n\r\nIn
+    this work, we present a t..."
+  embedPath: /videos/embed/d9a36c9f-1611-42f9-8854-981b1e2d7d75
+  thumbnailPath: /static/thumbnails/e5d18bd4-b482-463c-80f8-35d9fbb46b23.jpg
+  date: 2021-08-27T10:40:06.000Z
+  language: English
+  category: Science & Technology
+- name: Wibbily Wobbly Timey Camly
+  description: Time handling is commonly considered a difficult problem by programmers
+    due to myriad standards and complexity of time zone definitions. This also complicates
+    scheduling across multiple time zones especially when one takes Daylight Saving
+    Time int...
+  embedPath: /videos/embed/ec641446-823b-40ec-a207-85157a18f88e
+  thumbnailPath: /static/thumbnails/2300474a-7615-4c92-9489-9ff5117d8bc7.jpg
+  date: 2021-08-27T10:37:18.000Z
+  language: English
+  category: Science & Technology
+- name: 'Parafuzz: Coverage-guided Property Fuzzing for Multicore OCaml programs'
+  description: "We develop ParaFuzz, an input and concurrency fuzzing tool for Multicore
+    OCaml programs. ParaFuzz builds on top of Crowbar which combines AFL-based grey
+    box fuzzing with QuickCheck and extends it to handle parallelism.\r\n\r\nSumit
+    Padhiyar\r\nIndian In..."
+  embedPath: /videos/embed/c0d591e0-91c9-4eaa-a4d7-c4f514de0a57
+  thumbnailPath: /static/thumbnails/b1a67c0a-2eb9-4c9d-97ce-b4dc039da59b.jpg
+  date: 2021-08-27T10:36:13.000Z
+  language: English
+  category: Science & Technology
+- name: Deductive Verification of Realistic OCaml Code
+  description: We present the formal verification of a subset of the Set module from
+    the OCaml standard library. The proof is conducted using Cameleer, a new tool
+    for the deductive verification of OCaml code. Cameleer takes as input an OCaml
+    program, annotated u...
+  embedPath: /videos/embed/92309d92-8cbf-4545-980c-209c96e42a79
+  thumbnailPath: /static/thumbnails/db29d3bf-784c-47f1-bf90-f13fd2a9d530.jpg
+  date: 2021-08-27T10:33:38.000Z
+  language: English
+  category: Science & Technology
+- name: Adapting the OCaml ecosystem for Multicore OCaml
+  description: "OCaml 5.0 with support for shared-memory parallelism being around
+    the corner, there\u2019s increasing interest in the community to port existing
+    libraries to Multicore. This talk will take the attendees through what the arrival
+    of Multicore means to th..."
+  embedPath: /videos/embed/629b89a8-bbd5-490d-98b0-d0c740912b02
+  thumbnailPath: /static/thumbnails/41212c84-36d6-44fa-b884-2ced79505929.jpg
+  date: 2021-08-27T10:18:38.000Z
+  language: English
+  category: Science & Technology
+- name: 'OCaml and Python: Getting the Best of Both Worlds'
+  description: In this talk we present how we expose a wide variety of OCaml libraries
+    and services so that they can be accessed from Python. Our initial use case on
+    the Python side consisted in Jupyter notebooks used to analyse various datasets,
+    these datasets ...
+  embedPath: /videos/embed/9eafdb1e-9be9-4a52-98b4-f4696eda4c18
+  thumbnailPath: /static/thumbnails/53db83d1-0763-4dfa-a087-cce3cad1b581.jpg
+  date: 2021-08-27T10:16:54.000Z
+  language: English
+  category: Science & Technology
+- name: 'GopCaml: A Structural Editor for OCaml'
+  description: "This talk presents GopCaml-mode, the first structural editing plugin
+    for OCaml. We will give a tour of the main plugin features, discussing the plugin\u2019s
+    internal design and its integration with existing OCaml and GNU Emacs toolchains.\r\n\r\nKiran
+    Gop..."
+  embedPath: /videos/embed/e0a6e6f2-0d40-4dfc-9308-001c8e0f64d6
+  thumbnailPath: /static/thumbnails/729cda51-abb3-4c8d-9d0e-b922e81be518.jpg
+  date: 2021-08-27T10:12:58.000Z
+  language: English
+  category: Science & Technology
+- name: State of the OCaml Platform 2020
+  description: 'This talk covers:
+
+
+    - Integrated Development Environments
+
+    - Next Steps for the OCaml Platform
+
+    - Plans for 2020-2021'
+  embedPath: /videos/embed/0e2070fd-798b-47f7-8e69-ef75e967e516
+  thumbnailPath: /static/thumbnails/4fd6a51f-686c-4f6f-8026-83692304b432.jpg
+  date: 2020-08-28T00:00:00.000Z
+  language: English
+  category: Science & Technology
+- name: 'OCaml-CI : A Zero-Configuration CI'
+  description: "OCaml-CI\n\nis a CI service for OCaml projects. It\nuses metadata
+    from the project\u2019s opam and dune\nfiles to work out what to build, and uses
+    caching\nto make builds fast. It automatically tests projects\nagainst multiple
+    OCaml versions and OS platforms..."
+  embedPath: /videos/embed/0fee79e8-715a-400b-bfcc-34c3610f4890
+  thumbnailPath: /static/thumbnails/596f39a9-8654-4922-8bec-6e7ac5dcc319.jpg
+  date: 2020-08-28T00:00:00.000Z
+  language: English
+  category: Misc
+- name: The final pieces of the OCaml documentation puzzle
+  description: 'Rendering OCaml document is widely known as a very difficult task:
+    The ever-evolving OCaml module system is extremely rich and can include complex
+    set of inter-dependencies that are both difficult to compute and to render in
+    a concise document. It...'
+  embedPath: /videos/embed/2acebff9-25fa-4733-83cc-620a65b12251
+  thumbnailPath: /static/thumbnails/c877a501-c705-44f7-8826-e7ce846a5e42.jpg
+  date: 2020-08-28T00:00:00.000Z
+  language: English
+  category: Misc
+- name: 'API migration: compare transformed'
+  description: In this talk we describe our experience in using an automatic API-migration
+    strategy dedicated at changing the signatures of OCaml functions, using the Rotor
+    refactoring tool for OCaml. We perform a case study on open source Jane Street
+    libraries ...
+  embedPath: /videos/embed/c46b925b-bd77-404f-ac5d-5dab65047529
+  thumbnailPath: /static/thumbnails/eef64419-3c34-4c15-9419-edcbc455e54d.jpg
+  date: 2020-08-28T00:00:00.000Z
+  language: Unknown
+  category: Misc
+- name: Parallelising your OCaml Code with Multicore OCaml
+  description: 'Slides, speaker notes and runnable examples mentioned in this talk
+    are available at: https://github.com/ocaml-multicore/ocaml2020-workshop-parallel
+
+
+    With the availability of multicore variants of the recent OCaml versions (4.10
+    and 4.11) that main...'
+  embedPath: /videos/embed/ce20839e-4bfc-4d74-925b-485a6b052ddf
+  thumbnailPath: /static/thumbnails/30bc6019-ecab-40e5-a7b6-c294ac9a7344.jpg
+  date: 2020-08-28T00:00:00.000Z
+  language: Unknown
+  category: Misc
+- name: A Simple State-Machine Framework for Property-Based Testing in OCaml
+  description: "Since their inception, state-machine frameworks have proven their
+    worth by finding defects in everything from the underlying AUTOSAR components
+    of Volvo cars to digital invoicing systems. These case studies were carried out
+    with Erlang\u2019s commercia..."
+  embedPath: /videos/embed/08b429ea-2eb8-427d-a625-5495f4ee0fef
+  thumbnailPath: /static/thumbnails/316ddad9-dbc3-4d46-9f43-5da72689e93b.jpg
+  date: 2020-08-28T00:00:00.000Z
+  language: Unknown
+  category: Misc
+- name: The ImpFS filesystem
+  description: "This proposal describes a presentation to be given at the OCaml\u201920
+    workshop. The presentation will cover a new OCaml filesystem, ImpFS, and the related
+    libraries. The filesystem makes use of a B-tree library presented at OCaml\u201917,
+    and a key-value ..."
+  embedPath: /videos/embed/28545b27-4637-47a5-8edd-6b904daef19c
+  thumbnailPath: /static/thumbnails/dde19660-653d-4dc3-9e81-54b2e3ab22a2.jpg
+  date: 2020-08-28T00:00:00.000Z
+  language: Unknown
+  category: Misc
+- name: Irmin v2
+  description: 'Irmin is an OCaml library for building distributed databases with
+    the same design principles as Git. Existing Git users will find many familiar
+    features: branching/merging, immutable causal history for all changes, and the
+    ability to restore to an...'
+  embedPath: /videos/embed/53e497b0-898f-4c85-8da9-39f65ef0e0b1
+  thumbnailPath: /static/thumbnails/138e7c05-185b-4e54-95d0-d15018905a39.jpg
+  date: 2020-08-28T00:00:00.000Z
+  language: Unknown
+  category: Misc
+- name: 'AD-OCaml: Algorithmic Differentiation for OCaml'
+  description: AD-OCaml is a library framework for calculating mathematically exact
+    derivatives and deep power series approximations of almost arbitrary OCaml programs
+    via algorithmic differentiation. Unlike similar frameworks, this includes programs
+    with side e...
+  embedPath: /videos/embed/c9e85690-732f-4b03-836f-2ee0fd8f0658
+  thumbnailPath: /static/thumbnails/eb972fd2-668e-4998-a798-e9fbdcadba20.jpg
+  date: 2020-08-28T00:00:00.000Z
+  language: Unknown
+  category: Misc
+- name: 'OCaml Under The Hood: SmartPy'
+  description: SmartPy is a complete system to develop smart-contracts for the Tezos
+    blockchain. It is an embedded EDSL in python to write contracts and their test
+    scenarios. It includes an online IDE, a chain explorer, and a command-line interface.
+    Python is us...
+  embedPath: /videos/embed/7446ad4d-4ae2-4e1a-bc38-af8f71e8ebd8
+  thumbnailPath: /static/thumbnails/e1ac5b07-3648-40c1-b62c-5e88471741dc.jpg
+  date: 2020-08-28T00:00:00.000Z
+  language: Unknown
+  category: Misc
+- name: A Declarative Syntax Definition for OCaml
+  description: In this talk, we present our work on a syntax definition for the OCaml
+    language in the syntax definition formalism SDF3. SDF3 supports the high-level
+    definition of concrete and abstract syntax through declarative disambiguation
+    and definition of c...
+  embedPath: /videos/embed/a5b86864-8e43-4138-b6d6-ed48d2d4b63d
+  thumbnailPath: /static/thumbnails/92c0a0e3-5326-42aa-86a3-6adb3927e111.jpg
+  date: 2020-08-28T00:00:00.000Z
+  language: Unknown
+  category: Misc
+- name: LexiFi Runtime Types
+  description: OCaml programmers make deliberate use of abstract data types for composing
+    safe and reliable software systems. The OCaml compiler relies on the invariants
+    imposed by the type system to produce efficient and compact runtime data representations.
+    Be...
+  embedPath: /videos/embed/cc7e3242-0bef-448a-aa13-8827bba933e3
+  thumbnailPath: /static/thumbnails/1d43d8b4-87d1-4398-b925-10a42460b8dc.jpg
+  date: 2020-08-28T00:00:00.000Z
+  language: Unknown
+  category: Science & Technology
+- name: Types in Amber
+  description: Coda is a new cryptocurrency that uses zk-SNARKs to dramatically reduce
+    the size of data needed by nodes running its protocol. Nodes communicate in a
+    format automatically derived from type definitions in OCaml source files. As the
+    Coda software ev...
+  embedPath: /videos/embed/99b3dc75-9f93-4677-9f8b-076546725512
+  thumbnailPath: /static/thumbnails/acd50ed1-43cf-45fd-a55e-9c40a6bf58ba.jpg
+  date: 2020-08-28T00:00:00.000Z
+  language: Unknown
+  category: Misc
+- name: 'OCaml-CI : A Zero-Configuration CI'
+  description: "OCaml-CI1 is a CI service for OCaml projects. It uses metadata from
+    the project\u2019s opam and dune files to work out what to build, and uses caching
+    to make builds fast. It automatically tests projects against multiple OCaml versions
+    and OS platforms..."
+  embedPath: /videos/embed/da88d6ac-7ba1-4261-9308-d03fe21e35b9
+  thumbnailPath: /static/thumbnails/1c22a14e-f067-4d4e-8e26-027cc6d8a491.jpg
+  date: 2020-08-28T00:00:00.000Z
+  language: English
+  category: Science & Technology
+- name: The OCaml Platform 1.0 - Reason ML
+  description: 'Presented by Anil Madhavapeddy (@avsm)
+
+
+    We keep being told ReasonML can compile to native and do interop with OCaml, and
+    that there''s a wealth of existing code and tools we can draw into our applications
+    - but how do we get there?
+
+    This video will ...'
+  embedPath: /videos/embed/bd9a8e54-6ca5-4036-a08c-6a47cee6619e
+  thumbnailPath: /static/thumbnails/ddc1e6fb-9999-4e79-b458-31c7e3ec1108.jpg
+  date: 2018-12-11T00:00:00.000Z
+  language: English
+  category: Science & Technology
+- name: State of the OCaml Platform
+  embedPath: /videos/embed/390ce74c-f85f-477d-8f20-504437409add
+  thumbnailPath: /static/thumbnails/33258292-009b-42ee-83d3-9eb4bfb4e048.jpg
+  date: 2018-01-12T00:00:00.000Z
+  language: English
+  category: Science & Technology
+- name: Towards A Debugger for Native Code OCaml
+  embedPath: /videos/embed/b76f3301-261d-44f3-97ec-1910b45f6969
+  thumbnailPath: /static/thumbnails/93ea327e-5e8b-4844-b237-75719a7256b9.jpg
+  date: 2015-09-18T00:00:00.000Z
+  language: English
+  category: Science & Technology
+- name: 'Operf: Benchmarking the OCaml Compiler'
+  embedPath: /videos/embed/5a4a6c12-3cb1-40d2-a663-25f294e12555
+  thumbnailPath: /static/thumbnails/c2b5c90a-9c9e-4058-94a1-15525795a01a.jpg
+  date: 2015-09-18T00:00:00.000Z
+  language: English
+  category: Science & Technology
+- name: 'Core Time stamp counter: A fast high resolution time source'
+  embedPath: /videos/embed/75b4d60f-3e37-40bd-b025-f39dcce0c42c
+  thumbnailPath: /static/thumbnails/43248673-6478-4e96-b8ac-cd415d85569b.jpg
+  date: 2015-09-18T00:00:00.000Z
+  language: English
+  category: Science & Technology
+- name: Specialization of Generic Array Accesses After Inlining
+  embedPath: /videos/embed/80553916-b90a-4641-93c8-35b000df04c1
+  thumbnailPath: /static/thumbnails/1f81fbbf-6fb0-4047-93a1-57759431166a.jpg
+  date: 2015-09-18T00:00:00.000Z
+  language: Unknown
+  category: Science & Technology
+- name: Inline Assembly in OCaml
+  embedPath: /videos/embed/632f520f-8f83-4b6f-89f1-5cde088436c7
+  thumbnailPath: /static/thumbnails/5d2f65d1-6129-4206-832b-c3d4bab410df.jpg
+  date: 2015-09-18T00:00:00.000Z
+  language: English
+  category: Science & Technology
+- name: The State of OCaml
+  embedPath: /videos/embed/60a2ecfb-86ea-4881-a279-0a928452a3c3
+  thumbnailPath: /static/thumbnails/a5e5f630-2df9-4691-8ddf-a8137001ab4c.jpg
+  date: 2015-09-18T00:00:00.000Z
+  language: English
+  category: Science & Technology
+- name: The State of the OCaml Platform
+  embedPath: /videos/embed/32475a83-b455-455b-937f-28e7185f4fc2
+  thumbnailPath: /static/thumbnails/7eb8af05-a6d5-4a88-89f3-146673a87cf0.jpg
+  date: 2015-09-18T00:00:00.000Z
+  language: English
+  category: Science & Technology
+- name: Global Semantic Analysis on OCaml programs
+  embedPath: /videos/embed/51e4bdf0-50f7-4b13-8514-2d62b5341066
+  thumbnailPath: /static/thumbnails/8255d370-e621-44bc-b7c3-6dd39fab4d1d.jpg
+  date: 2015-09-18T00:00:00.000Z
+  language: English
+  category: Science & Technology
+- name: Effective Concurrency through Algebraic Effects
+  embedPath: /videos/embed/e9f6c837-1435-4349-af0f-07d22d1c11ea
+  thumbnailPath: /static/thumbnails/1de58bd2-d2f9-428c-8b8c-97b48d6d2c7e.jpg
+  date: 2015-09-18T00:00:00.000Z
+  language: English
+  category: Science & Technology
+- name: A review of the growth of the OCaml community
+  embedPath: /videos/embed/f9d0b637-8aec-4bff-8c32-cd16b58023b6
+  thumbnailPath: /static/thumbnails/e573402b-1350-4aa7-a9ba-0e1c51198fb4.jpg
+  date: 2015-09-18T00:00:00.000Z
+  language: Unknown
+  category: Science & Technology
+- name: Persistent Networking with Irmin and MirageOS
+  embedPath: /videos/embed/97dd9634-28e4-4066-96e4-9c2036ee4bb2
+  thumbnailPath: /static/thumbnails/46ba8c5d-0f4a-427e-8e76-0c58cb0e70a7.jpg
+  date: 2015-09-18T00:00:00.000Z
+  language: English
+  category: Science & Technology
+- name: Ketrew and Biokepi
+  embedPath: /videos/embed/f3dcee35-bc04-453a-ba35-7aec90599661
+  thumbnailPath: /static/thumbnails/0a36e8ce-c415-4191-ad5b-6ef2eb23db4e.jpg
+  date: 2015-09-18T00:00:00.000Z
+  language: English
+  category: Science & Technology

--- a/dune-project
+++ b/dune-project
@@ -38,7 +38,7 @@
   dream
   dream-cli
   dream-livereload
-  yaml
+  (yaml (>= 3.0))
   (omd
    (>= 2.0.0~alpha2))
   (ood
@@ -53,7 +53,7 @@
  (depends
   (ocaml
    (>= 4.08.0))
-  yaml
+  (yaml (>= 3.0))
   ppx_deriving_yaml
   ezjsonm
   ptime

--- a/ood-gen.opam
+++ b/ood-gen.opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/patricoferris/ood/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08.0"}
-  "yaml"
+  "yaml" {>= "3.0"}
   "ppx_deriving_yaml"
   "ezjsonm"
   "ptime"

--- a/ood-preview.opam
+++ b/ood-preview.opam
@@ -14,7 +14,7 @@ depends: [
   "dream"
   "dream-cli"
   "dream-livereload"
-  "yaml"
+  "yaml" {>= "3.0"}
   "omd" {>= "2.0.0~alpha2"}
   "ood" {= version}
   "alcotest" {with-test}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,1577 @@
 {
   "name": "ood",
   "version": "0.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "ood",
+      "version": "0.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "bs-platform": "9.0.2"
+      },
+      "devDependencies": {
+        "@tailwindcss/aspect-ratio": "^0.2.1",
+        "@tailwindcss/forms": "^0.3.3",
+        "@tailwindcss/typography": "^0.4.1",
+        "autoprefixer": "^10.3.3",
+        "tailwindcss": "^2.2.8"
+      },
+      "engines": {
+        "node": "14.x",
+        "yarn": ">= 1.22"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+      "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.14.5",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "node_modules/@babel/highlight/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@tailwindcss/aspect-ratio": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/aspect-ratio/-/aspect-ratio-0.2.1.tgz",
+      "integrity": "sha512-aDFi80aHQ3JM3symJ5iKU70lm151ugIGFCI0yRZGpyjgQSDS+Fbe93QwypC1tCEllQE8p0S7TUu20ih1b9IKLA==",
+      "dev": true,
+      "peerDependencies": {
+        "tailwindcss": ">=2.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/forms": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.3.3.tgz",
+      "integrity": "sha512-U8Fi/gq4mSuaLyLtFISwuDYzPB73YzgozjxOIHsK6NXgg/IWD1FLaHbFlWmurAMyy98O+ao74ksdQefsquBV1Q==",
+      "dev": true,
+      "dependencies": {
+        "mini-svg-data-uri": "^1.2.3"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=2.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.4.1.tgz",
+      "integrity": "sha512-ovPPLUhs7zAIJfr0y1dbGlyCuPhpuv/jpBoFgqAc658DWGGrOBWBMpAWLw2KlzbNeVk4YBJMzue1ekvIbdw6XA==",
+      "dev": true,
+      "dependencies": {
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "lodash.uniq": "^4.5.0"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=2.0.0"
+      }
+    },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
+    },
+    "node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-node": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
+      "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^7.0.0",
+        "acorn-walk": "^7.0.0",
+        "xtend": "^4.0.2"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.1.tgz",
+      "integrity": "sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA==",
+      "dev": true
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.3.3",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.3.3.tgz",
+      "integrity": "sha512-yRzjxfnggrP/+qVHlUuZz5FZzEbkT+Yt0/Df6ScEMnbbZBLzYB2W0KLxoQCW+THm1SpOsM1ZPcTHAwuvmibIsQ==",
+      "dev": true,
+      "dependencies": {
+        "browserslist": "^4.16.8",
+        "caniuse-lite": "^1.0.30001252",
+        "colorette": "^1.3.0",
+        "fraction.js": "^4.1.1",
+        "normalize-range": "^0.1.2",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.16.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.8.tgz",
+      "integrity": "sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==",
+      "dev": true,
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001251",
+        "colorette": "^1.3.0",
+        "electron-to-chromium": "^1.3.811",
+        "escalade": "^3.1.1",
+        "node-releases": "^1.1.75"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
+    },
+    "node_modules/bs-platform": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-9.0.2.tgz",
+      "integrity": "sha512-Ye9JqJ4Oa7mcjjoOVRYI8Uc2Cf8N7jQLWDcdUplY7996d/YErSR7WitmV7XnSwr4EvdrbwjEsg1NxNjUQv3ChA==",
+      "hasInstallScript": true,
+      "bin": {
+        "bsb": "bsb",
+        "bsc": "bsc",
+        "bsrefmt": "bsrefmt",
+        "bstracing": "lib/bstracing"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001252",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz",
+      "integrity": "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "dev": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/color": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.0.1.tgz",
+      "integrity": "sha512-rpZjOKN5O7naJxkH2Rx1sZzzBgaiWECc6BYXjeCE6kF0kcASJYbUq02u7JqIHwCb/j3NhV+QhRL2683aICeGZA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.6.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/color-string": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
+      "integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/colorette": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
+      "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==",
+      "dev": true
+    },
+    "node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/css-unit-converter": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.2.tgz",
+      "integrity": "sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA==",
+      "dev": true
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
+    },
+    "node_modules/detective": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.0.tgz",
+      "integrity": "sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==",
+      "dev": true,
+      "dependencies": {
+        "acorn-node": "^1.6.1",
+        "defined": "^1.0.0",
+        "minimist": "^1.1.1"
+      },
+      "bin": {
+        "detective": "bin/detective.js"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.3.822",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.822.tgz",
+      "integrity": "sha512-k7jG5oYYHxF4jx6PcqwHX3JVME/OjzolqOZiIogi9xtsfsmTjTdie4x88OakYFPEa8euciTgCCzvVNwvmjHb1Q==",
+      "dev": true
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/error-ex/node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
+      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.12.0.tgz",
+      "integrity": "sha512-VNX0QkHK3RsXVKr9KrlUv/FoTa0NdbYoHHl7uXHv2rzyHSlxjdNAKug2twd9luJxpcyNeAgf5iPPMutJO67Dfg==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.1.1.tgz",
+      "integrity": "sha512-MHOhvvxHTfRFpF1geTK9czMIZ6xclsEor2wkIGYYq+PxcQqT7vStJqjhe6S1TenZrMZzo+wlqOufBDVepUEgPg==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/infusion"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "node_modules/glob": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.1.tgz",
+      "integrity": "sha512-kEVjS71mQazDBHKcsq4E9u/vUzaLcw1A8EtUeydawvIWQCJM0qQ08G1H7/XTjFUulla6XQiDOG6MXSaG0HDKog==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+      "dev": true
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-tags": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
+      "integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/import-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz",
+      "integrity": "sha512-4pnzH16plW+hgvRECbDWpQl3cqtvSofHWh44met7ESfZ8UZOWWddm8hEyDTqREJ9RbYHY8gi8DqmaelApoOGMg==",
+      "dev": true,
+      "dependencies": {
+        "import-from": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
+      "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
+      "dev": true,
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/import-from/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "dev": true
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
+      "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.3.tgz",
+      "integrity": "sha512-EHKqr/+ZvdKCifpNrJCKxBTgk5XupZA3y/aCPY9mxfgBzmgh93Mt/WqjjQ38oMxXuvDokaKiM3lAgvSH2sjtHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "node_modules/lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha1-wCUTUV4wna3dTCTGDP3c9ZdtkRU=",
+      "dev": true
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "node_modules/lodash.topath": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.topath/-/lodash.topath-4.5.2.tgz",
+      "integrity": "sha1-NhY1Hzu6YZlKCTGYlmC9AyVP0Ak=",
+      "dev": true
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+      "dev": true
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.1",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mini-svg-data-uri": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.3.3.tgz",
+      "integrity": "sha512-+fA2oRcR1dJI/7ITmeQJDrYWks0wodlOz0pAEhKYJ2IVc1z0AnwJUsKY2fzFmPAM3Jo9J0rBx8JAA9QQSJ5PuA==",
+      "dev": true,
+      "bin": {
+        "mini-svg-data-uri": "cli.js"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "node_modules/modern-normalize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/modern-normalize/-/modern-normalize-1.1.0.tgz",
+      "integrity": "sha512-2lMlY1Yc1+CUy0gw4H95uNN7vjbpoED7NNRSBHE25nWfLBdmMzFCsPshlzbxHz+gYMcBEUN8V4pU16prcdPSgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+      "dev": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-emoji": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
+      "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "1.1.75",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
+      "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
+      "dev": true
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
+      "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
+      "dev": true,
+      "dependencies": {
+        "colorette": "^1.2.2",
+        "nanoid": "^3.1.23",
+        "source-map-js": "^0.6.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-3.0.3.tgz",
+      "integrity": "sha512-gWnoWQXKFw65Hk/mi2+WTQTHdPD5UJdDXZmX073EY/B3BWnYjO4F4t0VneTCnCGQ5E5GsCdMkzPaTXwl3r5dJw==",
+      "dev": true,
+      "dependencies": {
+        "camelcase-css": "^2.0.1",
+        "postcss": "^8.1.6"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.0.tgz",
+      "integrity": "sha512-ipM8Ds01ZUophjDTQYSVP70slFSYg3T0/zyfII5vzhN6V57YSxMgG5syXuwi5VtS8wSf3iL30v0uBdoIVx4Q0g==",
+      "dev": true,
+      "dependencies": {
+        "import-cwd": "^3.0.0",
+        "lilconfig": "^2.0.3",
+        "yaml": "^1.10.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-5.0.6.tgz",
+      "integrity": "sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==",
+      "dev": true,
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.6"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
+      "integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
+      "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
+      "dev": true
+    },
+    "node_modules/pretty-hrtime": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/purgecss": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-4.0.3.tgz",
+      "integrity": "sha512-PYOIn5ibRIP34PBU9zohUcCI09c7drPJJtTDAc0Q6QlRz2/CHQ8ywGLdE7ZhxU2VTqB7p5wkvj5Qcm05Rz3Jmw==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^6.0.0",
+        "glob": "^7.0.0",
+        "postcss": "^8.2.1",
+        "postcss-selector-parser": "^6.0.2"
+      },
+      "bin": {
+        "purgecss": "bin/purgecss.js"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/reduce-css-calc": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-2.1.8.tgz",
+      "integrity": "sha512-8liAVezDmUcH+tdzoEGrhfbGcP7nOV4NkGE3a74+qqvE7nt9i4sKLGBuZNOnpI4WiGksiNPklZxva80061QiPg==",
+      "dev": true,
+      "dependencies": {
+        "css-unit-converter": "^1.1.1",
+        "postcss-value-parser": "^3.3.0"
+      }
+    },
+    "node_modules/reduce-css-calc/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "dev": true
+    },
+    "node_modules/resolve": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
+      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-2.2.8.tgz",
+      "integrity": "sha512-sq6pKVIjklgtuj7OKn+6KD6UqNebYKZYUSx0oKx8aS1usdUXn1TLuwFyr/85HNYu5uHNduLFsXrtQJtkNmYlqQ==",
+      "dev": true,
+      "dependencies": {
+        "arg": "^5.0.1",
+        "bytes": "^3.0.0",
+        "chalk": "^4.1.2",
+        "chokidar": "^3.5.2",
+        "color": "^4.0.1",
+        "cosmiconfig": "^7.0.0",
+        "detective": "^5.2.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.2.7",
+        "fs-extra": "^10.0.0",
+        "glob-parent": "^6.0.1",
+        "html-tags": "^3.1.0",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.21",
+        "lodash.topath": "^4.5.2",
+        "modern-normalize": "^1.1.0",
+        "node-emoji": "^1.11.0",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^2.2.0",
+        "postcss-js": "^3.0.3",
+        "postcss-load-config": "^3.1.0",
+        "postcss-nested": "5.0.6",
+        "postcss-selector-parser": "^6.0.6",
+        "postcss-value-parser": "^4.1.0",
+        "pretty-hrtime": "^1.0.3",
+        "purgecss": "^4.0.3",
+        "quick-lru": "^5.1.1",
+        "reduce-css-calc": "^2.1.8",
+        "resolve": "^1.20.0",
+        "tmp": "^0.2.1"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      },
+      "peerDependencies": {
+        "autoprefixer": "^10.0.2",
+        "postcss": "^8.0.9"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "dev": true,
+      "dependencies": {
+        "rimraf": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.17.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    }
+  },
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.14.5",
@@ -112,7 +1681,8 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/aspect-ratio/-/aspect-ratio-0.2.1.tgz",
       "integrity": "sha512-aDFi80aHQ3JM3symJ5iKU70lm151ugIGFCI0yRZGpyjgQSDS+Fbe93QwypC1tCEllQE8p0S7TUu20ih1b9IKLA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@tailwindcss/forms": {
       "version": "0.3.3",

--- a/src/ood-gen/bin/dune
+++ b/src/ood-gen/bin/dune
@@ -29,5 +29,7 @@
 
 (executable
  (name watch_scrape)
+ (public_name ood-watch)
+ (package ood-gen)
  (modules watch_scrape)
  (libraries yaml ezjsonm piaf))

--- a/src/ood-gen/bin/watch_scrape.ml
+++ b/src/ood-gen/bin/watch_scrape.ml
@@ -1,76 +1,124 @@
 open Piaf
+open Lwt_result.Syntax
 
-type t = {
+type watch = {
   name : string;
   embedPath : string;
   thumbnailPath : string;
-  description : string;
-  year : string;
+  description : string option;
+  date : string;
   language : string;
   category : string;
 }
 
-(* Handling Ezjsonm.get_string Parse error *)
-let get_string_from_value json =
-  try Ezjsonm.get_string json
-  with Ezjsonm.Parse_error (`Null, "Ezjsonm.get_string") -> ""
+type t = { watch : watch list }
 
 (* extract year from originally published date string *)
 let get_year json =
-  let s = Ezjsonm.get_string json in
-  String.sub s 0 4
+  match Ezjsonm.find json [ "originallyPublishedAt" ] with
+  | `Null -> (
+      match Ezjsonm.find json [ "publishedAt" ] with
+      | `String s -> s
+      | _ -> failwith "Couldn't calculate the videos published date")
+  | `String s -> s
+  | _ -> failwith "Couldn't calculate the videos original publish date"
 
 (* extract value of language and category *)
 let get_language_category json =
   let label = Ezjsonm.find json [ "label" ] in
   Ezjsonm.get_string label
 
+let get_string_or_none = function `String s -> Some s | _ -> None
+
 let of_json json =
   {
     name = Ezjsonm.find json [ "name" ] |> Ezjsonm.get_string;
-    description = Ezjsonm.find json [ "description" ] |> get_string_from_value;
+    description = Ezjsonm.find json [ "description" ] |> get_string_or_none;
     embedPath = Ezjsonm.find json [ "embedPath" ] |> Ezjsonm.get_string;
     thumbnailPath = Ezjsonm.find json [ "thumbnailPath" ] |> Ezjsonm.get_string;
-    year = Ezjsonm.find json [ "originallyPublishedAt" ] |> get_year;
+    date = get_year json;
     language = Ezjsonm.find json [ "language" ] |> get_language_category;
     category = Ezjsonm.find json [ "category" ] |> get_language_category;
   }
 
-let to_yaml t =
+let watch_to_yaml t =
   `O
-    [
-      ("name", `String t.name);
-      ("description", `String t.description);
-      ("embedPath", `String t.embedPath);
-      ("thumbnailPath", `String t.thumbnailPath);
-      ("year", `String t.year);
-      ("language", `String t.language);
-      ("category", `String t.category);
-    ]
+    ([ ("name", `String t.name) ]
+    @ (match t.description with
+      | Some s -> [ ("description", `String s) ]
+      | None -> [])
+    @ [
+        ("embedPath", `String t.embedPath);
+        ("thumbnailPath", `String t.thumbnailPath);
+        ("date", `String t.date);
+        ("language", `String t.language);
+        ("category", `String t.category);
+      ])
 
-let get_sync url =
-  let open Lwt_result.Syntax in
-  Lwt_main.run
-    (print_endline "Sending request...";
+let to_yaml t = `O [ ("watch", `A (List.map watch_to_yaml t.watch)) ]
 
-     let* response = Client.Oneshot.get (Uri.of_string url) in
+let videos_url = Uri.of_string "https://watch.ocaml.org/api/v1/videos"
 
-     if Status.is_successful response.status then Body.to_string response.body
-     else
-       let message = Status.to_string response.status in
-       Lwt.return (Error (`Msg message)))
+(* 100 is current maximum the API can return: https://github.com/Chocobozzz/PeerTube/blob/develop/support/doc/api/openapi.yaml#L6338 *)
+let max_count_per_request = 100
+
+let get_videos ?start () =
+  let query_params =
+    match start with
+    | None -> [ ("count", [ string_of_int max_count_per_request ]) ]
+    | Some s ->
+        [
+          ("start", [ string_of_int s ]);
+          ("count", [ string_of_int max_count_per_request ]);
+        ]
+  in
+  let* response =
+    Client.Oneshot.get (Uri.add_query_params videos_url query_params)
+  in
+  let+ body = Body.to_string response.body in
+  let body = Ezjsonm.value_from_string body in
+  let data = Ezjsonm.(find body [ "data" ]) in
+  let total = Ezjsonm.find body [ "total" ] |> Ezjsonm.get_int in
+  (total, Ezjsonm.get_list of_json data)
+
+let get_all_videos () =
+  let get_videos_or_err results =
+    try
+      Ok
+        (List.map
+           (function Ok v -> v | Error err -> failwith (Error.to_string err))
+           results)
+    with Failure m -> Error (`Msg m)
+  in
+  let* total, first = get_videos () in
+  let+ rest =
+    if total > max_count_per_request then
+      (* Plus one for the remainder of the videos *)
+      let reqs = (total / max_count_per_request) + 1 in
+      (* Skip first amount as we have them *)
+      let offsets = List.init reqs (fun i -> max_count_per_request * (i + 1)) in
+      let* videos =
+        Lwt_result.ok
+        @@ Lwt_list.map_p
+             (fun start ->
+               let+ _total, videos = get_videos ~start () in
+               videos)
+             offsets
+      in
+      Lwt.return (get_videos_or_err videos)
+    else Lwt.return (Ok [])
+  in
+  List.concat (first :: rest)
+
+let run () =
+  match Lwt_main.run @@ get_all_videos () with
+  | Ok v -> v
+  | Error err ->
+      Fmt.epr "%s" (Error.to_string err);
+      exit 1
 
 let () =
-  let data () =
-    match get_sync "https://watch.ocaml.org/api/v1/videos" with
-    | Ok body -> Ezjsonm.value_from_string body
-    | Error error ->
-        let message = Error.to_string error in
-        failwith message
-  in
-
-  let v = data () in
-  let videos_json = Ezjsonm.find v [ "data" ] in
-  let videos = Ezjsonm.get_list of_json videos_json in
-  let yaml = `A (List.map to_yaml videos) in
+  let watch = run () in
+  let videos = { watch } in
+  let yaml = to_yaml videos in
   Yaml.pp Format.std_formatter yaml

--- a/src/ood-gen/bin/watch_scrape.ml
+++ b/src/ood-gen/bin/watch_scrape.ml
@@ -118,7 +118,9 @@ let run () =
       exit 1
 
 let () =
-  let watch = run () in
+  let watch =
+    run () |> List.stable_sort (fun w1 w2 -> String.compare w1.name w2.name)
+  in
   let videos = { watch } in
   let yaml = to_yaml videos in
   Yaml.pp Format.std_formatter yaml

--- a/src/ood-gen/bin/watch_scrape.mli
+++ b/src/ood-gen/bin/watch_scrape.mli
@@ -1,0 +1,1 @@
+(** Main entry point for our application. *)

--- a/src/ood-gen/lib/watch.ml
+++ b/src/ood-gen/lib/watch.ml
@@ -4,8 +4,8 @@ type metadata = {
   name : string;
   embedPath : string;
   thumbnailPath : string;
-  description : string;
-  year : int;
+  description : string option;
+  date : string;
   language : string;
   category : string;
 }
@@ -19,8 +19,8 @@ type t = {
   name : string;
   embedPath : string;
   thumbnailPath : string;
-  description : string;
-  year : int;
+  description : string option;
+  date : string;
   language : string;
   category : string;
 }
@@ -39,7 +39,7 @@ let decode s =
              description = metadata.description;
              embedPath = metadata.embedPath;
              thumbnailPath = metadata.thumbnailPath;
-             year = metadata.year;
+             date = metadata.date;
              language = metadata.language;
              category = metadata.category;
            }
@@ -58,12 +58,13 @@ let pp ppf v =
   ; embedPath = %a
   ; thumbnailPath = %a
   ; description = %a
-  ; year = %i
+  ; date = %a
   ; language = %a
   ; category = %a
   }|}
-    Pp.string v.name Pp.string v.embedPath Pp.string v.thumbnailPath Pp.string
-    v.description v.year Pp.string v.language Pp.string v.category
+    Pp.string v.name Pp.string v.embedPath Pp.string v.thumbnailPath
+    Pp.(option string)
+    v.description Pp.string v.date Pp.string v.language Pp.string v.category
 
 let pp_list = Pp.list pp
 
@@ -75,8 +76,8 @@ let template () =
   { name: string;
     embedPath : string;
     thumbnailPath : string;
-    description : string;
-    year : int;
+    description : string option;
+    date : string;
     language : string;
     category : string;
   }

--- a/src/ood-gen/lib/watch.ml
+++ b/src/ood-gen/lib/watch.ml
@@ -2,10 +2,11 @@
 
 type metadata = {
   name : string;
-  embedPath : string;
-  thumbnailPath : string;
+  embed_path : string;
+  thumbnail_path : string;
   description : string option;
-  date : string;
+  published_at : string;
+  updated_at : string;
   language : string;
   category : string;
 }
@@ -17,10 +18,11 @@ let parse content = Result.map metadata_of_yaml @@ Yaml.of_string content
 
 type t = {
   name : string;
-  embedPath : string;
-  thumbnailPath : string;
+  embed_path : string;
+  thumbnail_path : string;
   description : string option;
-  date : string;
+  published_at : string;
+  updated_at : string;
   language : string;
   category : string;
 }
@@ -37,9 +39,10 @@ let decode s =
           ({
              name = metadata.name;
              description = metadata.description;
-             embedPath = metadata.embedPath;
-             thumbnailPath = metadata.thumbnailPath;
-             date = metadata.date;
+             embed_path = metadata.embed_path;
+             thumbnail_path = metadata.thumbnail_path;
+             published_at = metadata.published_at;
+             updated_at = metadata.updated_at;
              language = metadata.language;
              category = metadata.category;
            }
@@ -55,16 +58,18 @@ let pp ppf v =
   Fmt.pf ppf
     {|
   { name = %a
-  ; embedPath = %a
-  ; thumbnailPath = %a
+  ; embed_path = %a
+  ; thumbnail_path = %a
   ; description = %a
-  ; date = %a
+  ; published_at = %a
+  ; updated_at = %a
   ; language = %a
   ; category = %a
   }|}
-    Pp.string v.name Pp.string v.embedPath Pp.string v.thumbnailPath
+    Pp.string v.name Pp.string v.embed_path Pp.string v.thumbnail_path
     Pp.(option string)
-    v.description Pp.string v.date Pp.string v.language Pp.string v.category
+    v.description Pp.string v.published_at Pp.string v.updated_at Pp.string
+    v.language Pp.string v.category
 
 let pp_list = Pp.list pp
 
@@ -74,10 +79,11 @@ let template () =
 
   type t =
   { name: string;
-    embedPath : string;
-    thumbnailPath : string;
+    embed_path : string;
+    thumbnail_path : string;
     description : string option;
-    date : string;
+    published_at : string;
+    updated_at : string;
     language : string;
     category : string;
   }

--- a/src/ood-preview/asset/main.css
+++ b/src/ood-preview/asset/main.css
@@ -1,4 +1,6 @@
-/*! tailwindcss v2.1.4 | MIT License | https://tailwindcss.com *//*! modern-normalize v1.1.0 | MIT License | https://github.com/sindresorhus/modern-normalize */
+/*! tailwindcss v2.2.8 | MIT License | https://tailwindcss.com */
+
+/*! modern-normalize v1.1.0 | MIT License | https://github.com/sindresorhus/modern-normalize */
 
 /*
 Document
@@ -12,7 +14,7 @@ Use a better box model (opinionated).
 *,
 ::before,
 ::after {
-	box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 /**
@@ -20,8 +22,9 @@ Use a more readable tab size (opinionated).
 */
 
 html {
-	-moz-tab-size: 4;
-	tab-size: 4;
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+     tab-size: 4;
 }
 
 /**
@@ -30,8 +33,10 @@ html {
 */
 
 html {
-	line-height: 1.15; /* 1 */
-	-webkit-text-size-adjust: 100%; /* 2 */
+  line-height: 1.15;
+  /* 1 */
+  -webkit-text-size-adjust: 100%;
+  /* 2 */
 }
 
 /*
@@ -44,7 +49,7 @@ Remove the margin in all browsers.
 */
 
 body {
-	margin: 0;
+  margin: 0;
 }
 
 /**
@@ -52,7 +57,7 @@ Improve consistency of default fonts in all browsers. (https://github.com/sindre
 */
 
 body {
-	font-family:
+  font-family:
 		system-ui,
 		-apple-system, /* Firefox supports this but not yet `system-ui` */
 		'Segoe UI',
@@ -75,8 +80,10 @@ Grouping content
 */
 
 hr {
-	height: 0; /* 1 */
-	color: inherit; /* 2 */
+  height: 0;
+  /* 1 */
+  color: inherit;
+  /* 2 */
 }
 
 /*
@@ -89,8 +96,8 @@ Add the correct text decoration in Chrome, Edge, and Safari.
 */
 
 abbr[title] {
-	-webkit-text-decoration: underline dotted;
-	        text-decoration: underline dotted;
+  -webkit-text-decoration: underline dotted;
+          text-decoration: underline dotted;
 }
 
 /**
@@ -99,7 +106,7 @@ Add the correct font weight in Edge and Safari.
 
 b,
 strong {
-	font-weight: bolder;
+  font-weight: bolder;
 }
 
 /**
@@ -111,14 +118,16 @@ code,
 kbd,
 samp,
 pre {
-	font-family:
+  font-family:
 		ui-monospace,
 		SFMono-Regular,
 		Consolas,
 		'Liberation Mono',
 		Menlo,
-		monospace; /* 1 */
-	font-size: 1em; /* 2 */
+		monospace;
+  /* 1 */
+  font-size: 1em;
+  /* 2 */
 }
 
 /**
@@ -126,7 +135,7 @@ Add the correct font size in all browsers.
 */
 
 small {
-	font-size: 80%;
+  font-size: 80%;
 }
 
 /**
@@ -135,18 +144,18 @@ Prevent 'sub' and 'sup' elements from affecting the line height in all browsers.
 
 sub,
 sup {
-	font-size: 75%;
-	line-height: 0;
-	position: relative;
-	vertical-align: baseline;
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
 }
 
 sub {
-	bottom: -0.25em;
+  bottom: -0.25em;
 }
 
 sup {
-	top: -0.5em;
+  top: -0.5em;
 }
 
 /*
@@ -160,8 +169,10 @@ Tabular data
 */
 
 table {
-	text-indent: 0; /* 1 */
-	border-color: inherit; /* 2 */
+  text-indent: 0;
+  /* 1 */
+  border-color: inherit;
+  /* 2 */
 }
 
 /*
@@ -179,10 +190,14 @@ input,
 optgroup,
 select,
 textarea {
-	font-family: inherit; /* 1 */
-	font-size: 100%; /* 1 */
-	line-height: 1.15; /* 1 */
-	margin: 0; /* 2 */
+  font-family: inherit;
+  /* 1 */
+  font-size: 100%;
+  /* 1 */
+  line-height: 1.15;
+  /* 1 */
+  margin: 0;
+  /* 2 */
 }
 
 /**
@@ -191,8 +206,9 @@ Remove the inheritance of text transform in Edge and Firefox.
 */
 
 button,
-select { /* 1 */
-	text-transform: none;
+select {
+  /* 1 */
+  text-transform: none;
 }
 
 /**
@@ -203,7 +219,7 @@ button,
 [type='button'],
 [type='reset'],
 [type='submit'] {
-	-webkit-appearance: button;
+  -webkit-appearance: button;
 }
 
 /**
@@ -211,8 +227,8 @@ Remove the inner border and padding in Firefox.
 */
 
 ::-moz-focus-inner {
-	border-style: none;
-	padding: 0;
+  border-style: none;
+  padding: 0;
 }
 
 /**
@@ -220,7 +236,7 @@ Restore the focus styles unset by the previous rule.
 */
 
 :-moz-focusring {
-	outline: 1px dotted ButtonText;
+  outline: 1px dotted ButtonText;
 }
 
 /**
@@ -229,7 +245,7 @@ See: https://github.com/mozilla/gecko-dev/blob/2f9eacd9d3d995c937b4251a5557d95d4
 */
 
 :-moz-ui-invalid {
-	box-shadow: none;
+  box-shadow: none;
 }
 
 /**
@@ -237,7 +253,7 @@ Remove the padding so developers are not caught out when they zero out 'fieldset
 */
 
 legend {
-	padding: 0;
+  padding: 0;
 }
 
 /**
@@ -245,7 +261,7 @@ Add the correct vertical alignment in Chrome and Firefox.
 */
 
 progress {
-	vertical-align: baseline;
+  vertical-align: baseline;
 }
 
 /**
@@ -254,7 +270,7 @@ Correct the cursor style of increment and decrement buttons in Safari.
 
 ::-webkit-inner-spin-button,
 ::-webkit-outer-spin-button {
-	height: auto;
+  height: auto;
 }
 
 /**
@@ -263,8 +279,10 @@ Correct the cursor style of increment and decrement buttons in Safari.
 */
 
 [type='search'] {
-	-webkit-appearance: textfield; /* 1 */
-	outline-offset: -2px; /* 2 */
+  -webkit-appearance: textfield;
+  /* 1 */
+  outline-offset: -2px;
+  /* 2 */
 }
 
 /**
@@ -272,7 +290,7 @@ Remove the inner padding in Chrome and Safari on macOS.
 */
 
 ::-webkit-search-decoration {
-	-webkit-appearance: none;
+  -webkit-appearance: none;
 }
 
 /**
@@ -281,8 +299,10 @@ Remove the inner padding in Chrome and Safari on macOS.
 */
 
 ::-webkit-file-upload-button {
-	-webkit-appearance: button; /* 1 */
-	font: inherit; /* 2 */
+  -webkit-appearance: button;
+  /* 1 */
+  font: inherit;
+  /* 2 */
 }
 
 /*
@@ -295,8 +315,10 @@ Add the correct display in Chrome and Safari.
 */
 
 summary {
-	display: list-item;
-}/**
+  display: list-item;
+}
+
+/**
  * Manually forked from SUIT CSS Base: https://github.com/suitcss/base
  * A thin layer on top of normalize.css that provides a starting point more
  * suitable for web applications.
@@ -327,16 +349,6 @@ button {
   background-image: none;
 }
 
-/**
- * Work around a Firefox/IE bug where the transparent `button` background
- * results in a loss of the default `button` focus styles.
- */
-
-button:focus {
-  outline: 1px dotted;
-  outline: 5px auto -webkit-focus-ring-color;
-}
-
 fieldset {
   margin: 0;
   padding: 0;
@@ -361,10 +373,11 @@ ul {
  */
 
 html {
-  font-family: Inter var, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"; /* 1 */
-  line-height: 1.5; /* 2 */
+  font-family: Inter var, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  /* 1 */
+  line-height: 1.5;
+  /* 2 */
 }
-
 
 /**
  * Inherit font-family and line-height from `html` so users can set them as
@@ -405,10 +418,14 @@ body {
 *,
 ::before,
 ::after {
-  box-sizing: border-box; /* 1 */
-  border-width: 0; /* 2 */
-  border-style: solid; /* 2 */
-  border-color: #e5e7eb; /* 2 */
+  box-sizing: border-box;
+  /* 1 */
+  border-width: 0;
+  /* 2 */
+  border-style: solid;
+  /* 2 */
+  border-color: currentColor;
+  /* 2 */
 }
 
 /*
@@ -437,6 +454,16 @@ textarea {
   resize: vertical;
 }
 
+input::-moz-placeholder, textarea::-moz-placeholder {
+  opacity: 1;
+  color: #9ca3af;
+}
+
+input:-ms-input-placeholder, textarea:-ms-input-placeholder {
+  opacity: 1;
+  color: #9ca3af;
+}
+
 input::placeholder,
 textarea::placeholder {
   opacity: 1;
@@ -446,6 +473,18 @@ textarea::placeholder {
 button,
 [role="button"] {
   cursor: pointer;
+}
+
+/**
+ * Override legacy focus reset from Normalize with modern Firefox focus styles.
+ *
+ * This is actually an improvement over the new defaults in Firefox in our testing,
+ * as it triggers the better focus styles even for links, which still use a dotted
+ * outline in Firefox by default.
+ */
+
+:-moz-focusring {
+  outline: auto;
 }
 
 table {
@@ -505,11 +544,20 @@ samp {
 }
 
 /**
- * Make replaced elements `display: block` by default as that's
- * the behavior you want almost all of the time. Inspired by
- * CSS Remedy, with `svg` added as well.
+ * 1. Make replaced elements `display: block` by default as that's
+ *    the behavior you want almost all of the time. Inspired by
+ *    CSS Remedy, with `svg` added as well.
  *
- * https://github.com/mozdevs/cssremedy/issues/14
+ *    https://github.com/mozdevs/cssremedy/issues/14
+ * 
+ * 2. Add `vertical-align: middle` to align replaced elements more
+ *    sensibly by default when overriding `display` by adding a
+ *    utility like `inline`.
+ *
+ *    This can trigger a poorly considered linting error in some
+ *    tools but is included by design.
+ * 
+ *    https://github.com/jensimmons/cssremedy/issues/14#issuecomment-634934210
  */
 
 img,
@@ -521,7 +569,9 @@ iframe,
 embed,
 object {
   display: block;
+  /* 1 */
   vertical-align: middle;
+  /* 2 */
 }
 
 /**
@@ -537,655 +587,814 @@ video {
   height: auto;
 }
 
-* {
-	--tw-shadow: 0 0 #0000;
-	--tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
-	--tw-ring-offset-width: 0px;
-	--tw-ring-offset-color: #fff;
-	--tw-ring-color: rgba(59, 130, 246, 0.5);
-	--tw-ring-offset-shadow: 0 0 #0000;
-	--tw-ring-shadow: 0 0 #0000;
+/**
+ * Ensure the default browser behavior of the `hidden` attribute.
+ */
+
+[hidden] {
+  display: none;
+}
+
+*, ::before, ::after {
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  --tw-transform: translateX(var(--tw-translate-x)) translateY(var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+  --tw-border-opacity: 1;
+  border-color: rgba(229, 231, 235, var(--tw-border-opacity));
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+  --tw-shadow: 0 0 #0000;
+  --tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: rgba(59, 130, 246, 0.5);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+  --tw-shadow: 0 0 #0000;
+  --tw-blur: var(--tw-empty,/*!*/ /*!*/);
+  --tw-brightness: var(--tw-empty,/*!*/ /*!*/);
+  --tw-contrast: var(--tw-empty,/*!*/ /*!*/);
+  --tw-grayscale: var(--tw-empty,/*!*/ /*!*/);
+  --tw-hue-rotate: var(--tw-empty,/*!*/ /*!*/);
+  --tw-invert: var(--tw-empty,/*!*/ /*!*/);
+  --tw-saturate: var(--tw-empty,/*!*/ /*!*/);
+  --tw-sepia: var(--tw-empty,/*!*/ /*!*/);
+  --tw-drop-shadow: var(--tw-empty,/*!*/ /*!*/);
+  --tw-filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
 }
 
 [type='text'],[type='email'],[type='url'],[type='password'],[type='number'],[type='date'],[type='datetime-local'],[type='month'],[type='search'],[type='tel'],[type='time'],[type='week'],[multiple],textarea,select {
-	-webkit-appearance: none;
-	        appearance: none;
-	background-color: #fff;
-	border-color: #6b7280;
-	border-width: 1px;
-	border-radius: 0px;
-	padding-top: 0.5rem;
-	padding-right: 0.75rem;
-	padding-bottom: 0.5rem;
-	padding-left: 0.75rem;
-	font-size: 1rem;
-	line-height: 1.5rem;
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none;
+  background-color: #fff;
+  border-color: #6b7280;
+  border-width: 1px;
+  border-radius: 0px;
+  padding-top: 0.5rem;
+  padding-right: 0.75rem;
+  padding-bottom: 0.5rem;
+  padding-left: 0.75rem;
+  font-size: 1rem;
+  line-height: 1.5rem;
 }
 
 [type='text']:focus, [type='email']:focus, [type='url']:focus, [type='password']:focus, [type='number']:focus, [type='date']:focus, [type='datetime-local']:focus, [type='month']:focus, [type='search']:focus, [type='tel']:focus, [type='time']:focus, [type='week']:focus, [multiple]:focus, textarea:focus, select:focus {
-	outline: 2px solid transparent;
-	outline-offset: 2px;
-	--tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
-	--tw-ring-offset-width: 0px;
-	--tw-ring-offset-color: #fff;
-	--tw-ring-color: #2563eb;
-	--tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
-	--tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
-	box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
-	border-color: #2563eb;
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  --tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: #2563eb;
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+  border-color: #2563eb;
+}
+
+input::-moz-placeholder, textarea::-moz-placeholder {
+  color: #6b7280;
+  opacity: 1;
+}
+
+input:-ms-input-placeholder, textarea:-ms-input-placeholder {
+  color: #6b7280;
+  opacity: 1;
 }
 
 input::placeholder,textarea::placeholder {
-	color: #6b7280;
-	opacity: 1;
+  color: #6b7280;
+  opacity: 1;
 }
 
 ::-webkit-datetime-edit-fields-wrapper {
-	padding: 0;
+  padding: 0;
 }
 
 ::-webkit-date-and-time-value {
-	min-height: 1.5em;
+  min-height: 1.5em;
 }
 
 select {
-	background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
-	background-position: right 0.5rem center;
-	background-repeat: no-repeat;
-	background-size: 1.5em 1.5em;
-	padding-right: 2.5rem;
-	-webkit-print-color-adjust: exact;
-	        color-adjust: exact;
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
+  background-position: right 0.5rem center;
+  background-repeat: no-repeat;
+  background-size: 1.5em 1.5em;
+  padding-right: 2.5rem;
+  -webkit-print-color-adjust: exact;
+          color-adjust: exact;
 }
 
 [multiple] {
-	background-image: initial;
-	background-position: initial;
-	background-repeat: unset;
-	background-size: initial;
-	padding-right: 0.75rem;
-	-webkit-print-color-adjust: unset;
-	        color-adjust: unset;
+  background-image: initial;
+  background-position: initial;
+  background-repeat: unset;
+  background-size: initial;
+  padding-right: 0.75rem;
+  -webkit-print-color-adjust: unset;
+          color-adjust: unset;
 }
 
 [type='checkbox'],[type='radio'] {
-	-webkit-appearance: none;
-	        appearance: none;
-	padding: 0;
-	-webkit-print-color-adjust: exact;
-	        color-adjust: exact;
-	display: inline-block;
-	vertical-align: middle;
-	background-origin: border-box;
-	-webkit-user-select: none;
-	        user-select: none;
-	flex-shrink: 0;
-	height: 1rem;
-	width: 1rem;
-	color: #2563eb;
-	background-color: #fff;
-	border-color: #6b7280;
-	border-width: 1px;
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none;
+  padding: 0;
+  -webkit-print-color-adjust: exact;
+          color-adjust: exact;
+  display: inline-block;
+  vertical-align: middle;
+  background-origin: border-box;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
+  flex-shrink: 0;
+  height: 1rem;
+  width: 1rem;
+  color: #2563eb;
+  background-color: #fff;
+  border-color: #6b7280;
+  border-width: 1px;
 }
 
 [type='checkbox'] {
-	border-radius: 0px;
+  border-radius: 0px;
 }
 
 [type='radio'] {
-	border-radius: 100%;
+  border-radius: 100%;
 }
 
 [type='checkbox']:focus,[type='radio']:focus {
-	outline: 2px solid transparent;
-	outline-offset: 2px;
-	--tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
-	--tw-ring-offset-width: 2px;
-	--tw-ring-offset-color: #fff;
-	--tw-ring-color: #2563eb;
-	--tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
-	--tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
-	box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  --tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
+  --tw-ring-offset-width: 2px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: #2563eb;
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
 }
 
 [type='checkbox']:checked,[type='radio']:checked {
-	border-color: transparent;
-	background-color: currentColor;
-	background-size: 100% 100%;
-	background-position: center;
-	background-repeat: no-repeat;
+  border-color: transparent;
+  background-color: currentColor;
+  background-size: 100% 100%;
+  background-position: center;
+  background-repeat: no-repeat;
 }
 
 [type='checkbox']:checked {
-	background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
+  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
 }
 
 [type='radio']:checked {
-	background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='8' cy='8' r='3'/%3e%3c/svg%3e");
+  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='8' cy='8' r='3'/%3e%3c/svg%3e");
 }
 
 [type='checkbox']:checked:hover,[type='checkbox']:checked:focus,[type='radio']:checked:hover,[type='radio']:checked:focus {
-	border-color: transparent;
-	background-color: currentColor;
+  border-color: transparent;
+  background-color: currentColor;
 }
 
 [type='checkbox']:indeterminate {
-	background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 16 16'%3e%3cpath stroke='white' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 8h8'/%3e%3c/svg%3e");
-	border-color: transparent;
-	background-color: currentColor;
-	background-size: 100% 100%;
-	background-position: center;
-	background-repeat: no-repeat;
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 16 16'%3e%3cpath stroke='white' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 8h8'/%3e%3c/svg%3e");
+  border-color: transparent;
+  background-color: currentColor;
+  background-size: 100% 100%;
+  background-position: center;
+  background-repeat: no-repeat;
 }
 
 [type='checkbox']:indeterminate:hover,[type='checkbox']:indeterminate:focus {
-	border-color: transparent;
-	background-color: currentColor;
+  border-color: transparent;
+  background-color: currentColor;
 }
 
 [type='file'] {
-	background: unset;
-	border-color: inherit;
-	border-width: 0;
-	border-radius: 0;
-	padding: 0;
-	font-size: unset;
-	line-height: inherit;
+  background: unset;
+  border-color: inherit;
+  border-width: 0;
+  border-radius: 0;
+  padding: 0;
+  font-size: unset;
+  line-height: inherit;
 }
 
 [type='file']:focus {
-	outline: 1px auto -webkit-focus-ring-color;
-}
-      .prose {
-	color: #374151;
-	max-width: 65ch;
-}
-      .prose [class~="lead"] {
-	color: #4b5563;
-	font-size: 1.25em;
-	line-height: 1.6;
-	margin-top: 1.2em;
-	margin-bottom: 1.2em;
-}
-      .prose a {
-	color: #111827;
-	text-decoration: underline;
-	font-weight: 500;
-}
-      .prose strong {
-	color: #111827;
-	font-weight: 600;
-}
-      .prose ol[type="A"] {
-	--list-counter-style: upper-alpha;
-}
-      .prose ol[type="a"] {
-	--list-counter-style: lower-alpha;
-}
-      .prose ol[type="A" s] {
-	--list-counter-style: upper-alpha;
-}
-      .prose ol[type="a" s] {
-	--list-counter-style: lower-alpha;
-}
-      .prose ol[type="I"] {
-	--list-counter-style: upper-roman;
-}
-      .prose ol[type="i"] {
-	--list-counter-style: lower-roman;
-}
-      .prose ol[type="I" s] {
-	--list-counter-style: upper-roman;
-}
-      .prose ol[type="i" s] {
-	--list-counter-style: lower-roman;
-}
-      .prose ol[type="1"] {
-	--list-counter-style: decimal;
-}
-      .prose ol > li {
-	position: relative;
-	padding-left: 1.75em;
-}
-      .prose ol > li::before {
-	content: counter(list-item, var(--list-counter-style, decimal)) ".";
-	position: absolute;
-	font-weight: 400;
-	color: #6b7280;
-	left: 0;
-}
-      .prose ul > li {
-	position: relative;
-	padding-left: 1.75em;
-}
-      .prose ul > li::before {
-	content: "";
-	position: absolute;
-	background-color: #d1d5db;
-	border-radius: 50%;
-	width: 0.375em;
-	height: 0.375em;
-	top: calc(0.875em - 0.1875em);
-	left: 0.25em;
-}
-      .prose hr {
-	border-color: #e5e7eb;
-	border-top-width: 1px;
-	margin-top: 3em;
-	margin-bottom: 3em;
-}
-      .prose blockquote {
-	font-weight: 500;
-	font-style: italic;
-	color: #111827;
-	border-left-width: 0.25rem;
-	border-left-color: #e5e7eb;
-	quotes: "\201C""\201D""\2018""\2019";
-	margin-top: 1.6em;
-	margin-bottom: 1.6em;
-	padding-left: 1em;
-}
-      .prose blockquote p:first-of-type::before {
-	content: open-quote;
-}
-      .prose blockquote p:last-of-type::after {
-	content: close-quote;
-}
-      .prose h1 {
-	color: #111827;
-	font-weight: 800;
-	font-size: 2.25em;
-	margin-top: 0;
-	margin-bottom: 0.8888889em;
-	line-height: 1.1111111;
-}
-      .prose h2 {
-	color: #111827;
-	font-weight: 700;
-	font-size: 1.5em;
-	margin-top: 2em;
-	margin-bottom: 1em;
-	line-height: 1.3333333;
-}
-      .prose h3 {
-	color: #111827;
-	font-weight: 600;
-	font-size: 1.25em;
-	margin-top: 1.6em;
-	margin-bottom: 0.6em;
-	line-height: 1.6;
-}
-      .prose h4 {
-	color: #111827;
-	font-weight: 600;
-	margin-top: 1.5em;
-	margin-bottom: 0.5em;
-	line-height: 1.5;
-}
-      .prose figure figcaption {
-	color: #6b7280;
-	font-size: 0.875em;
-	line-height: 1.4285714;
-	margin-top: 0.8571429em;
-}
-      .prose code {
-	color: #111827;
-	font-weight: 600;
-	font-size: 0.875em;
-}
-      .prose code::before {
-	content: "`";
-}
-      .prose code::after {
-	content: "`";
-}
-      .prose a code {
-	color: #111827;
-}
-      .prose pre {
-	color: #e5e7eb;
-	background-color: #1f2937;
-	overflow-x: auto;
-	font-size: 0.875em;
-	line-height: 1.7142857;
-	margin-top: 1.7142857em;
-	margin-bottom: 1.7142857em;
-	border-radius: 0.375rem;
-	padding-top: 0.8571429em;
-	padding-right: 1.1428571em;
-	padding-bottom: 0.8571429em;
-	padding-left: 1.1428571em;
-}
-      .prose pre code {
-	background-color: transparent;
-	border-width: 0;
-	border-radius: 0;
-	padding: 0;
-	font-weight: 400;
-	color: inherit;
-	font-size: inherit;
-	font-family: inherit;
-	line-height: inherit;
-}
-      .prose pre code::before {
-	content: none;
-}
-      .prose pre code::after {
-	content: none;
-}
-      .prose table {
-	width: 100%;
-	table-layout: auto;
-	text-align: left;
-	margin-top: 2em;
-	margin-bottom: 2em;
-	font-size: 0.875em;
-	line-height: 1.7142857;
-}
-      .prose thead {
-	color: #111827;
-	font-weight: 600;
-	border-bottom-width: 1px;
-	border-bottom-color: #d1d5db;
-}
-      .prose thead th {
-	vertical-align: bottom;
-	padding-right: 0.5714286em;
-	padding-bottom: 0.5714286em;
-	padding-left: 0.5714286em;
-}
-      .prose tbody tr {
-	border-bottom-width: 1px;
-	border-bottom-color: #e5e7eb;
-}
-      .prose tbody tr:last-child {
-	border-bottom-width: 0;
-}
-      .prose tbody td {
-	vertical-align: top;
-	padding-top: 0.5714286em;
-	padding-right: 0.5714286em;
-	padding-bottom: 0.5714286em;
-	padding-left: 0.5714286em;
-}
-      .prose {
-	font-size: 1rem;
-	line-height: 1.75;
-}
-      .prose p {
-	margin-top: 1.25em;
-	margin-bottom: 1.25em;
-}
-      .prose img {
-	margin-top: 2em;
-	margin-bottom: 2em;
-}
-      .prose video {
-	margin-top: 2em;
-	margin-bottom: 2em;
-}
-      .prose figure {
-	margin-top: 2em;
-	margin-bottom: 2em;
-}
-      .prose figure > * {
-	margin-top: 0;
-	margin-bottom: 0;
-}
-      .prose h2 code {
-	font-size: 0.875em;
-}
-      .prose h3 code {
-	font-size: 0.9em;
-}
-      .prose ol {
-	margin-top: 1.25em;
-	margin-bottom: 1.25em;
-}
-      .prose ul {
-	margin-top: 1.25em;
-	margin-bottom: 1.25em;
-}
-      .prose li {
-	margin-top: 0.5em;
-	margin-bottom: 0.5em;
-}
-      .prose > ul > li p {
-	margin-top: 0.75em;
-	margin-bottom: 0.75em;
-}
-      .prose > ul > li > *:first-child {
-	margin-top: 1.25em;
-}
-      .prose > ul > li > *:last-child {
-	margin-bottom: 1.25em;
-}
-      .prose > ol > li > *:first-child {
-	margin-top: 1.25em;
-}
-      .prose > ol > li > *:last-child {
-	margin-bottom: 1.25em;
-}
-      .prose ul ul, .prose ul ol, .prose ol ul, .prose ol ol {
-	margin-top: 0.75em;
-	margin-bottom: 0.75em;
-}
-      .prose hr + * {
-	margin-top: 0;
-}
-      .prose h2 + * {
-	margin-top: 0;
-}
-      .prose h3 + * {
-	margin-top: 0;
-}
-      .prose h4 + * {
-	margin-top: 0;
-}
-      .prose thead th:first-child {
-	padding-left: 0;
-}
-      .prose thead th:last-child {
-	padding-right: 0;
-}
-      .prose tbody td:first-child {
-	padding-left: 0;
-}
-      .prose tbody td:last-child {
-	padding-right: 0;
-}
-      .prose > :first-child {
-	margin-top: 0;
-}
-      .prose > :last-child {
-	margin-bottom: 0;
-}
-      .prose-lg {
-	font-size: 1.125rem;
-	line-height: 1.7777778;
-}
-      .prose-lg p {
-	margin-top: 1.3333333em;
-	margin-bottom: 1.3333333em;
-}
-      .prose-lg [class~="lead"] {
-	font-size: 1.2222222em;
-	line-height: 1.4545455;
-	margin-top: 1.0909091em;
-	margin-bottom: 1.0909091em;
-}
-      .prose-lg blockquote {
-	margin-top: 1.6666667em;
-	margin-bottom: 1.6666667em;
-	padding-left: 1em;
-}
-      .prose-lg h1 {
-	font-size: 2.6666667em;
-	margin-top: 0;
-	margin-bottom: 0.8333333em;
-	line-height: 1;
-}
-      .prose-lg h2 {
-	font-size: 1.6666667em;
-	margin-top: 1.8666667em;
-	margin-bottom: 1.0666667em;
-	line-height: 1.3333333;
-}
-      .prose-lg h3 {
-	font-size: 1.3333333em;
-	margin-top: 1.6666667em;
-	margin-bottom: 0.6666667em;
-	line-height: 1.5;
-}
-      .prose-lg h4 {
-	margin-top: 1.7777778em;
-	margin-bottom: 0.4444444em;
-	line-height: 1.5555556;
-}
-      .prose-lg img {
-	margin-top: 1.7777778em;
-	margin-bottom: 1.7777778em;
-}
-      .prose-lg video {
-	margin-top: 1.7777778em;
-	margin-bottom: 1.7777778em;
-}
-      .prose-lg figure {
-	margin-top: 1.7777778em;
-	margin-bottom: 1.7777778em;
-}
-      .prose-lg figure > * {
-	margin-top: 0;
-	margin-bottom: 0;
-}
-      .prose-lg figure figcaption {
-	font-size: 0.8888889em;
-	line-height: 1.5;
-	margin-top: 1em;
-}
-      .prose-lg code {
-	font-size: 0.8888889em;
-}
-      .prose-lg h2 code {
-	font-size: 0.8666667em;
-}
-      .prose-lg h3 code {
-	font-size: 0.875em;
-}
-      .prose-lg pre {
-	font-size: 0.8888889em;
-	line-height: 1.75;
-	margin-top: 2em;
-	margin-bottom: 2em;
-	border-radius: 0.375rem;
-	padding-top: 1em;
-	padding-right: 1.5em;
-	padding-bottom: 1em;
-	padding-left: 1.5em;
-}
-      .prose-lg ol {
-	margin-top: 1.3333333em;
-	margin-bottom: 1.3333333em;
-}
-      .prose-lg ul {
-	margin-top: 1.3333333em;
-	margin-bottom: 1.3333333em;
-}
-      .prose-lg li {
-	margin-top: 0.6666667em;
-	margin-bottom: 0.6666667em;
-}
-      .prose-lg ol > li {
-	padding-left: 1.6666667em;
-}
-      .prose-lg ol > li::before {
-	left: 0;
-}
-      .prose-lg ul > li {
-	padding-left: 1.6666667em;
-}
-      .prose-lg ul > li::before {
-	width: 0.3333333em;
-	height: 0.3333333em;
-	top: calc(0.8888889em - 0.1666667em);
-	left: 0.2222222em;
-}
-      .prose-lg > ul > li p {
-	margin-top: 0.8888889em;
-	margin-bottom: 0.8888889em;
-}
-      .prose-lg > ul > li > *:first-child {
-	margin-top: 1.3333333em;
-}
-      .prose-lg > ul > li > *:last-child {
-	margin-bottom: 1.3333333em;
-}
-      .prose-lg > ol > li > *:first-child {
-	margin-top: 1.3333333em;
-}
-      .prose-lg > ol > li > *:last-child {
-	margin-bottom: 1.3333333em;
-}
-      .prose-lg ul ul, .prose-lg ul ol, .prose-lg ol ul, .prose-lg ol ol {
-	margin-top: 0.8888889em;
-	margin-bottom: 0.8888889em;
-}
-      .prose-lg hr {
-	margin-top: 3.1111111em;
-	margin-bottom: 3.1111111em;
-}
-      .prose-lg hr + * {
-	margin-top: 0;
-}
-      .prose-lg h2 + * {
-	margin-top: 0;
-}
-      .prose-lg h3 + * {
-	margin-top: 0;
-}
-      .prose-lg h4 + * {
-	margin-top: 0;
-}
-      .prose-lg table {
-	font-size: 0.8888889em;
-	line-height: 1.5;
-}
-      .prose-lg thead th {
-	padding-right: 0.75em;
-	padding-bottom: 0.75em;
-	padding-left: 0.75em;
-}
-      .prose-lg thead th:first-child {
-	padding-left: 0;
-}
-      .prose-lg thead th:last-child {
-	padding-right: 0;
-}
-      .prose-lg tbody td {
-	padding-top: 0.75em;
-	padding-right: 0.75em;
-	padding-bottom: 0.75em;
-	padding-left: 0.75em;
-}
-      .prose-lg tbody td:first-child {
-	padding-left: 0;
-}
-      .prose-lg tbody td:last-child {
-	padding-right: 0;
-}
-      .prose-lg > :first-child {
-	margin-top: 0;
-}
-      .prose-lg > :last-child {
-	margin-bottom: 0;
-}
-      .prose-indigo a {
-	color: #4f46e5;
-}
-      .prose-indigo a code {
-	color: #4f46e5;
-}
-      .aspect-w-1,
+  outline: 1px auto -webkit-focus-ring-color;
+}
+
+.prose {
+  color: #374151;
+  max-width: 65ch;
+}
+
+.prose [class~="lead"] {
+  color: #4b5563;
+  font-size: 1.25em;
+  line-height: 1.6;
+  margin-top: 1.2em;
+  margin-bottom: 1.2em;
+}
+
+.prose a {
+  color: #111827;
+  text-decoration: underline;
+  font-weight: 500;
+}
+
+.prose strong {
+  color: #111827;
+  font-weight: 600;
+}
+
+.prose ol[type="A"] {
+  --list-counter-style: upper-alpha;
+}
+
+.prose ol[type="a"] {
+  --list-counter-style: lower-alpha;
+}
+
+.prose ol[type="A" s] {
+  --list-counter-style: upper-alpha;
+}
+
+.prose ol[type="a" s] {
+  --list-counter-style: lower-alpha;
+}
+
+.prose ol[type="I"] {
+  --list-counter-style: upper-roman;
+}
+
+.prose ol[type="i"] {
+  --list-counter-style: lower-roman;
+}
+
+.prose ol[type="I" s] {
+  --list-counter-style: upper-roman;
+}
+
+.prose ol[type="i" s] {
+  --list-counter-style: lower-roman;
+}
+
+.prose ol[type="1"] {
+  --list-counter-style: decimal;
+}
+
+.prose ol > li {
+  position: relative;
+  padding-left: 1.75em;
+}
+
+.prose ol > li::before {
+  content: counter(list-item, var(--list-counter-style, decimal)) ".";
+  position: absolute;
+  font-weight: 400;
+  color: #6b7280;
+  left: 0;
+}
+
+.prose ul > li {
+  position: relative;
+  padding-left: 1.75em;
+}
+
+.prose ul > li::before {
+  content: "";
+  position: absolute;
+  background-color: #d1d5db;
+  border-radius: 50%;
+  width: 0.375em;
+  height: 0.375em;
+  top: calc(0.875em - 0.1875em);
+  left: 0.25em;
+}
+
+.prose hr {
+  border-color: #e5e7eb;
+  border-top-width: 1px;
+  margin-top: 3em;
+  margin-bottom: 3em;
+}
+
+.prose blockquote {
+  font-weight: 500;
+  font-style: italic;
+  color: #111827;
+  border-left-width: 0.25rem;
+  border-left-color: #e5e7eb;
+  quotes: "\201C""\201D""\2018""\2019";
+  margin-top: 1.6em;
+  margin-bottom: 1.6em;
+  padding-left: 1em;
+}
+
+.prose blockquote p:first-of-type::before {
+  content: open-quote;
+}
+
+.prose blockquote p:last-of-type::after {
+  content: close-quote;
+}
+
+.prose h1 {
+  color: #111827;
+  font-weight: 800;
+  font-size: 2.25em;
+  margin-top: 0;
+  margin-bottom: 0.8888889em;
+  line-height: 1.1111111;
+}
+
+.prose h2 {
+  color: #111827;
+  font-weight: 700;
+  font-size: 1.5em;
+  margin-top: 2em;
+  margin-bottom: 1em;
+  line-height: 1.3333333;
+}
+
+.prose h3 {
+  color: #111827;
+  font-weight: 600;
+  font-size: 1.25em;
+  margin-top: 1.6em;
+  margin-bottom: 0.6em;
+  line-height: 1.6;
+}
+
+.prose h4 {
+  color: #111827;
+  font-weight: 600;
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+  line-height: 1.5;
+}
+
+.prose figure figcaption {
+  color: #6b7280;
+  font-size: 0.875em;
+  line-height: 1.4285714;
+  margin-top: 0.8571429em;
+}
+
+.prose code {
+  color: #111827;
+  font-weight: 600;
+  font-size: 0.875em;
+}
+
+.prose code::before {
+  content: "`";
+}
+
+.prose code::after {
+  content: "`";
+}
+
+.prose a code {
+  color: #111827;
+}
+
+.prose pre {
+  color: #e5e7eb;
+  background-color: #1f2937;
+  overflow-x: auto;
+  font-size: 0.875em;
+  line-height: 1.7142857;
+  margin-top: 1.7142857em;
+  margin-bottom: 1.7142857em;
+  border-radius: 0.375rem;
+  padding-top: 0.8571429em;
+  padding-right: 1.1428571em;
+  padding-bottom: 0.8571429em;
+  padding-left: 1.1428571em;
+}
+
+.prose pre code {
+  background-color: transparent;
+  border-width: 0;
+  border-radius: 0;
+  padding: 0;
+  font-weight: 400;
+  color: inherit;
+  font-size: inherit;
+  font-family: inherit;
+  line-height: inherit;
+}
+
+.prose pre code::before {
+  content: none;
+}
+
+.prose pre code::after {
+  content: none;
+}
+
+.prose table {
+  width: 100%;
+  table-layout: auto;
+  text-align: left;
+  margin-top: 2em;
+  margin-bottom: 2em;
+  font-size: 0.875em;
+  line-height: 1.7142857;
+}
+
+.prose thead {
+  color: #111827;
+  font-weight: 600;
+  border-bottom-width: 1px;
+  border-bottom-color: #d1d5db;
+}
+
+.prose thead th {
+  vertical-align: bottom;
+  padding-right: 0.5714286em;
+  padding-bottom: 0.5714286em;
+  padding-left: 0.5714286em;
+}
+
+.prose tbody tr {
+  border-bottom-width: 1px;
+  border-bottom-color: #e5e7eb;
+}
+
+.prose tbody tr:last-child {
+  border-bottom-width: 0;
+}
+
+.prose tbody td {
+  vertical-align: top;
+  padding-top: 0.5714286em;
+  padding-right: 0.5714286em;
+  padding-bottom: 0.5714286em;
+  padding-left: 0.5714286em;
+}
+
+.prose {
+  font-size: 1rem;
+  line-height: 1.75;
+}
+
+.prose p {
+  margin-top: 1.25em;
+  margin-bottom: 1.25em;
+}
+
+.prose img {
+  margin-top: 2em;
+  margin-bottom: 2em;
+}
+
+.prose video {
+  margin-top: 2em;
+  margin-bottom: 2em;
+}
+
+.prose figure {
+  margin-top: 2em;
+  margin-bottom: 2em;
+}
+
+.prose figure > * {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.prose h2 code {
+  font-size: 0.875em;
+}
+
+.prose h3 code {
+  font-size: 0.9em;
+}
+
+.prose ol {
+  margin-top: 1.25em;
+  margin-bottom: 1.25em;
+}
+
+.prose ul {
+  margin-top: 1.25em;
+  margin-bottom: 1.25em;
+}
+
+.prose li {
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+}
+
+.prose > ul > li p {
+  margin-top: 0.75em;
+  margin-bottom: 0.75em;
+}
+
+.prose > ul > li > *:first-child {
+  margin-top: 1.25em;
+}
+
+.prose > ul > li > *:last-child {
+  margin-bottom: 1.25em;
+}
+
+.prose > ol > li > *:first-child {
+  margin-top: 1.25em;
+}
+
+.prose > ol > li > *:last-child {
+  margin-bottom: 1.25em;
+}
+
+.prose ul ul, .prose ul ol, .prose ol ul, .prose ol ol {
+  margin-top: 0.75em;
+  margin-bottom: 0.75em;
+}
+
+.prose hr + * {
+  margin-top: 0;
+}
+
+.prose h2 + * {
+  margin-top: 0;
+}
+
+.prose h3 + * {
+  margin-top: 0;
+}
+
+.prose h4 + * {
+  margin-top: 0;
+}
+
+.prose thead th:first-child {
+  padding-left: 0;
+}
+
+.prose thead th:last-child {
+  padding-right: 0;
+}
+
+.prose tbody td:first-child {
+  padding-left: 0;
+}
+
+.prose tbody td:last-child {
+  padding-right: 0;
+}
+
+.prose > :first-child {
+  margin-top: 0;
+}
+
+.prose > :last-child {
+  margin-bottom: 0;
+}
+
+.prose-lg {
+  font-size: 1.125rem;
+  line-height: 1.7777778;
+}
+
+.prose-lg p {
+  margin-top: 1.3333333em;
+  margin-bottom: 1.3333333em;
+}
+
+.prose-lg [class~="lead"] {
+  font-size: 1.2222222em;
+  line-height: 1.4545455;
+  margin-top: 1.0909091em;
+  margin-bottom: 1.0909091em;
+}
+
+.prose-lg blockquote {
+  margin-top: 1.6666667em;
+  margin-bottom: 1.6666667em;
+  padding-left: 1em;
+}
+
+.prose-lg h1 {
+  font-size: 2.6666667em;
+  margin-top: 0;
+  margin-bottom: 0.8333333em;
+  line-height: 1;
+}
+
+.prose-lg h2 {
+  font-size: 1.6666667em;
+  margin-top: 1.8666667em;
+  margin-bottom: 1.0666667em;
+  line-height: 1.3333333;
+}
+
+.prose-lg h3 {
+  font-size: 1.3333333em;
+  margin-top: 1.6666667em;
+  margin-bottom: 0.6666667em;
+  line-height: 1.5;
+}
+
+.prose-lg h4 {
+  margin-top: 1.7777778em;
+  margin-bottom: 0.4444444em;
+  line-height: 1.5555556;
+}
+
+.prose-lg img {
+  margin-top: 1.7777778em;
+  margin-bottom: 1.7777778em;
+}
+
+.prose-lg video {
+  margin-top: 1.7777778em;
+  margin-bottom: 1.7777778em;
+}
+
+.prose-lg figure {
+  margin-top: 1.7777778em;
+  margin-bottom: 1.7777778em;
+}
+
+.prose-lg figure > * {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.prose-lg figure figcaption {
+  font-size: 0.8888889em;
+  line-height: 1.5;
+  margin-top: 1em;
+}
+
+.prose-lg code {
+  font-size: 0.8888889em;
+}
+
+.prose-lg h2 code {
+  font-size: 0.8666667em;
+}
+
+.prose-lg h3 code {
+  font-size: 0.875em;
+}
+
+.prose-lg pre {
+  font-size: 0.8888889em;
+  line-height: 1.75;
+  margin-top: 2em;
+  margin-bottom: 2em;
+  border-radius: 0.375rem;
+  padding-top: 1em;
+  padding-right: 1.5em;
+  padding-bottom: 1em;
+  padding-left: 1.5em;
+}
+
+.prose-lg ol {
+  margin-top: 1.3333333em;
+  margin-bottom: 1.3333333em;
+}
+
+.prose-lg ul {
+  margin-top: 1.3333333em;
+  margin-bottom: 1.3333333em;
+}
+
+.prose-lg li {
+  margin-top: 0.6666667em;
+  margin-bottom: 0.6666667em;
+}
+
+.prose-lg ol > li {
+  padding-left: 1.6666667em;
+}
+
+.prose-lg ol > li::before {
+  left: 0;
+}
+
+.prose-lg ul > li {
+  padding-left: 1.6666667em;
+}
+
+.prose-lg ul > li::before {
+  width: 0.3333333em;
+  height: 0.3333333em;
+  top: calc(0.8888889em - 0.1666667em);
+  left: 0.2222222em;
+}
+
+.prose-lg > ul > li p {
+  margin-top: 0.8888889em;
+  margin-bottom: 0.8888889em;
+}
+
+.prose-lg > ul > li > *:first-child {
+  margin-top: 1.3333333em;
+}
+
+.prose-lg > ul > li > *:last-child {
+  margin-bottom: 1.3333333em;
+}
+
+.prose-lg > ol > li > *:first-child {
+  margin-top: 1.3333333em;
+}
+
+.prose-lg > ol > li > *:last-child {
+  margin-bottom: 1.3333333em;
+}
+
+.prose-lg ul ul, .prose-lg ul ol, .prose-lg ol ul, .prose-lg ol ol {
+  margin-top: 0.8888889em;
+  margin-bottom: 0.8888889em;
+}
+
+.prose-lg hr {
+  margin-top: 3.1111111em;
+  margin-bottom: 3.1111111em;
+}
+
+.prose-lg hr + * {
+  margin-top: 0;
+}
+
+.prose-lg h2 + * {
+  margin-top: 0;
+}
+
+.prose-lg h3 + * {
+  margin-top: 0;
+}
+
+.prose-lg h4 + * {
+  margin-top: 0;
+}
+
+.prose-lg table {
+  font-size: 0.8888889em;
+  line-height: 1.5;
+}
+
+.prose-lg thead th {
+  padding-right: 0.75em;
+  padding-bottom: 0.75em;
+  padding-left: 0.75em;
+}
+
+.prose-lg thead th:first-child {
+  padding-left: 0;
+}
+
+.prose-lg thead th:last-child {
+  padding-right: 0;
+}
+
+.prose-lg tbody td {
+  padding-top: 0.75em;
+  padding-right: 0.75em;
+  padding-bottom: 0.75em;
+  padding-left: 0.75em;
+}
+
+.prose-lg tbody td:first-child {
+  padding-left: 0;
+}
+
+.prose-lg tbody td:last-child {
+  padding-right: 0;
+}
+
+.prose-lg > :first-child {
+  margin-top: 0;
+}
+
+.prose-lg > :last-child {
+  margin-bottom: 0;
+}
+
+.prose-indigo a {
+  color: #4f46e5;
+}
+
+.prose-indigo a code {
+  color: #4f46e5;
+}
+
+.aspect-w-1,
 .aspect-w-2,
 .aspect-w-3,
 .aspect-w-4,
@@ -1201,10 +1410,11 @@ select {
 .aspect-w-14,
 .aspect-w-15,
 .aspect-w-16 {
-	position: relative;
-	padding-bottom: calc(var(--tw-aspect-h) / var(--tw-aspect-w) * 100%);
+  position: relative;
+  padding-bottom: calc(var(--tw-aspect-h) / var(--tw-aspect-w) * 100%);
 }
-      .aspect-w-1 > *,
+
+.aspect-w-1 > *,
 .aspect-w-2 > *,
 .aspect-w-3 > *,
 .aspect-w-4 > *,
@@ -1220,774 +1430,980 @@ select {
 .aspect-w-14 > *,
 .aspect-w-15 > *,
 .aspect-w-16 > * {
-	position: absolute;
-	height: 100%;
-	width: 100%;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	left: 0;
+  position: absolute;
+  height: 100%;
+  width: 100%;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
 }
-      .aspect-w-3 {
-	--tw-aspect-w: 3;
-}
-      .aspect-h-2 {
-	--tw-aspect-h: 2;
-}
-      .sr-only {
-	position: absolute;
-	width: 1px;
-	height: 1px;
-	padding: 0;
-	margin: -1px;
-	overflow: hidden;
-	clip: rect(0, 0, 0, 0);
-	white-space: nowrap;
-	border-width: 0;
-}
-      .pointer-events-none {
-	pointer-events: none;
-}
-      .relative {
-	position: relative;
-}
-      .absolute {
-	position: absolute;
-}
-      .fixed {
-	position: fixed;
-}
-      .inset-0 {
-	top: 0px;
-	right: 0px;
-	bottom: 0px;
-	left: 0px;
-}
-      .inset-x-0 {
-	left: 0px;
-	right: 0px;
-}
-      .left-1\/2 {
-	left: 50%;
-}
-      .top-0 {
-	top: 0px;
-}
-      .top-7 {
-	top: 1.75rem;
-}
-      .left-7 {
-	left: 1.75rem;
-}
-      .z-10 {
-	z-index: 10;
-}
-      .z-30 {
-	z-index: 30;
-}
-      .z-50 {
-	z-index: 50;
-}
-      .col-span-1 {
-	grid-column: span 1 / span 1;
-}
-      .-m-3 {
-	margin: -0.75rem;
-}
-      .mx-auto {
-	margin-left: auto;
-	margin-right: auto;
-}
-      .-my-2 {
-	margin-top: -0.5rem;
-	margin-bottom: -0.5rem;
-}
-      .mt-2 {
-	margin-top: 0.5rem;
-}
-      .mt-6 {
-	margin-top: 1.5rem;
-}
-      .mt-5 {
-	margin-top: 1.25rem;
-}
-      .mt-1 {
-	margin-top: 0.25rem;
-}
-      .ml-2 {
-	margin-left: 0.5rem;
-}
-      .mt-3 {
-	margin-top: 0.75rem;
-}
-      .-mr-2 {
-	margin-right: -0.5rem;
-}
-      .ml-4 {
-	margin-left: 1rem;
-}
-      .mt-12 {
-	margin-top: 3rem;
-}
-      .-mb-8 {
-	margin-bottom: -2rem;
-}
-      .-ml-px {
-	margin-left: -1px;
-}
-      .mt-0\.5 {
-	margin-top: 0.125rem;
-}
-      .mt-0 {
-	margin-top: 0px;
-}
-      .mt-8 {
-	margin-top: 2rem;
-}
-      .block {
-	display: block;
-}
-      .inline-block {
-	display: inline-block;
-}
-      .flex {
-	display: flex;
-}
-      .inline-flex {
-	display: inline-flex;
-}
-      .table {
-	display: table;
-}
-      .flow-root {
-	display: flow-root;
-}
-      .grid {
-	display: grid;
-}
-      .hidden {
-	display: none;
-}
-      .h-5 {
-	height: 1.25rem;
-}
-      .h-8 {
-	height: 2rem;
-}
-      .h-6 {
-	height: 1.5rem;
-}
-      .h-10 {
-	height: 2.5rem;
-}
-      .h-48 {
-	height: 12rem;
-}
-      .h-full {
-	height: 100%;
-}
-      .h-14 {
-	height: 3.5rem;
-}
-      .w-5 {
-	width: 1.25rem;
-}
-      .w-screen {
-	width: 100vw;
-}
-      .w-auto {
-	width: auto;
-}
-      .w-6 {
-	width: 1.5rem;
-}
-      .w-10 {
-	width: 2.5rem;
-}
-      .w-full {
-	width: 100%;
-}
-      .w-0\.5 {
-	width: 0.125rem;
-}
-      .w-0 {
-	width: 0px;
-}
-      .w-14 {
-	width: 3.5rem;
-}
-      .min-w-full {
-	min-width: 100%;
-}
-      .min-w-0 {
-	min-width: 0px;
-}
-      .max-w-prose {
-	max-width: 65ch;
-}
-      .max-w-md {
-	max-width: 28rem;
-}
-      .max-w-xl {
-	max-width: 36rem;
-}
-      .max-w-7xl {
-	max-width: 80rem;
-}
-      .max-w-xs {
-	max-width: 20rem;
-}
-      .max-w-3xl {
-	max-width: 48rem;
-}
-      .max-w-none {
-	max-width: none;
-}
-      .max-w-lg {
-	max-width: 32rem;
-}
-      .max-w-6xl {
-	max-width: 72rem;
-}
-      .max-w-2xl {
-	max-width: 42rem;
-}
-      .max-w-full {
-	max-width: 100%;
-}
-      .flex-1 {
-	flex: 1 1 0%;
-}
-      .flex-shrink-0 {
-	flex-shrink: 0;
-}
-      .transform {
-	--tw-translate-x: 0;
-	--tw-translate-y: 0;
-	--tw-rotate: 0;
-	--tw-skew-x: 0;
-	--tw-skew-y: 0;
-	--tw-scale-x: 1;
-	--tw-scale-y: 1;
-	transform: translateX(var(--tw-translate-x)) translateY(var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-}
-      .origin-top-right {
-	transform-origin: top right;
-}
-      .translate-y-1 {
-	--tw-translate-y: 0.25rem;
-}
-      .translate-y-0 {
-	--tw-translate-y: 0px;
-}
-      .-translate-x-1\/2 {
-	--tw-translate-x: -50%;
-}
-      .scale-95 {
-	--tw-scale-x: .95;
-	--tw-scale-y: .95;
-}
-      .scale-100 {
-	--tw-scale-x: 1;
-	--tw-scale-y: 1;
-}
-      .scale-90 {
-	--tw-scale-x: .9;
-	--tw-scale-y: .9;
-}
-      .cursor-pointer {
-	cursor: pointer;
-}
-      .grid-cols-2 {
-	grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-      .grid-cols-1 {
-	grid-template-columns: repeat(1, minmax(0, 1fr));
-}
-      .flex-col {
-	flex-direction: column;
-}
-      .items-center {
-	align-items: center;
-}
-      .items-start {
-	align-items: flex-start;
-}
-      .justify-between {
-	justify-content: space-between;
-}
-      .justify-center {
-	justify-content: center;
-}
-      .gap-6 {
-	gap: 1.5rem;
-}
-      .gap-0\.5 {
-	gap: 0.125rem;
-}
-      .gap-0 {
-	gap: 0px;
-}
-      .gap-5 {
-	gap: 1.25rem;
-}
-      .gap-x-4 {
-	column-gap: 1rem;
-}
-      .gap-y-8 {
-	row-gap: 2rem;
-}
-      .space-y-8 > :not([hidden]) ~ :not([hidden]) {
-	--tw-space-y-reverse: 0;
-	margin-top: calc(2rem * calc(1 - var(--tw-space-y-reverse)));
-	margin-bottom: calc(2rem * var(--tw-space-y-reverse));
-}
-      .space-y-4 > :not([hidden]) ~ :not([hidden]) {
-	--tw-space-y-reverse: 0;
-	margin-top: calc(1rem * calc(1 - var(--tw-space-y-reverse)));
-	margin-bottom: calc(1rem * var(--tw-space-y-reverse));
-}
-      .space-x-10 > :not([hidden]) ~ :not([hidden]) {
-	--tw-space-x-reverse: 0;
-	margin-right: calc(2.5rem * var(--tw-space-x-reverse));
-	margin-left: calc(2.5rem * calc(1 - var(--tw-space-x-reverse)));
-}
-      .space-x-3 > :not([hidden]) ~ :not([hidden]) {
-	--tw-space-x-reverse: 0;
-	margin-right: calc(0.75rem * var(--tw-space-x-reverse));
-	margin-left: calc(0.75rem * calc(1 - var(--tw-space-x-reverse)));
-}
-      .space-y-1 > :not([hidden]) ~ :not([hidden]) {
-	--tw-space-y-reverse: 0;
-	margin-top: calc(0.25rem * calc(1 - var(--tw-space-y-reverse)));
-	margin-bottom: calc(0.25rem * var(--tw-space-y-reverse));
-}
-      .divide-y-2 > :not([hidden]) ~ :not([hidden]) {
-	--tw-divide-y-reverse: 0;
-	border-top-width: calc(2px * calc(1 - var(--tw-divide-y-reverse)));
-	border-bottom-width: calc(2px * var(--tw-divide-y-reverse));
-}
-      .divide-y > :not([hidden]) ~ :not([hidden]) {
-	--tw-divide-y-reverse: 0;
-	border-top-width: calc(1px * calc(1 - var(--tw-divide-y-reverse)));
-	border-bottom-width: calc(1px * var(--tw-divide-y-reverse));
-}
-      .divide-gray-50 > :not([hidden]) ~ :not([hidden]) {
-	--tw-divide-opacity: 1;
-	border-color: rgba(249, 250, 251, var(--tw-divide-opacity));
-}
-      .divide-gray-200 > :not([hidden]) ~ :not([hidden]) {
-	--tw-divide-opacity: 1;
-	border-color: rgba(229, 231, 235, var(--tw-divide-opacity));
-}
-      .overflow-hidden {
-	overflow: hidden;
-}
-      .overflow-auto {
-	overflow: auto;
-}
-      .overflow-x-auto {
-	overflow-x: auto;
-}
-      .truncate {
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-      .rounded-lg {
-	border-radius: 0.5rem;
-}
-      .rounded-md {
-	border-radius: 0.375rem;
-}
-      .rounded {
-	border-radius: 0.25rem;
-}
-      .rounded-full {
-	border-radius: 9999px;
-}
-      .border-b {
-	border-bottom-width: 1px;
-}
-      .border-t {
-	border-top-width: 1px;
-}
-      .border-gray-200 {
-	--tw-border-opacity: 1;
-	border-color: rgba(229, 231, 235, var(--tw-border-opacity));
-}
-      .bg-white {
-	--tw-bg-opacity: 1;
-	background-color: rgba(255, 255, 255, var(--tw-bg-opacity));
-}
-      .bg-indigo-500 {
-	--tw-bg-opacity: 1;
-	background-color: rgba(99, 102, 241, var(--tw-bg-opacity));
-}
-      .bg-gray-200 {
-	--tw-bg-opacity: 1;
-	background-color: rgba(229, 231, 235, var(--tw-bg-opacity));
-}
-      .bg-black {
-	--tw-bg-opacity: 1;
-	background-color: rgba(0, 0, 0, var(--tw-bg-opacity));
-}
-      .bg-graylight {
-	--tw-bg-opacity: 1;
-	background-color: rgba(245, 245, 245, var(--tw-bg-opacity));
-}
-      .bg-green-100 {
-	--tw-bg-opacity: 1;
-	background-color: rgba(209, 250, 229, var(--tw-bg-opacity));
-}
-      .bg-gray-50 {
-	--tw-bg-opacity: 1;
-	background-color: rgba(249, 250, 251, var(--tw-bg-opacity));
-}
-      .bg-blue-400 {
-	--tw-bg-opacity: 1;
-	background-color: rgba(96, 165, 250, var(--tw-bg-opacity));
-}
-      .bg-green-400 {
-	--tw-bg-opacity: 1;
-	background-color: rgba(52, 211, 153, var(--tw-bg-opacity));
-}
-      .bg-pink-400 {
-	--tw-bg-opacity: 1;
-	background-color: rgba(244, 114, 182, var(--tw-bg-opacity));
-}
-      .bg-red-400 {
-	--tw-bg-opacity: 1;
-	background-color: rgba(248, 113, 113, var(--tw-bg-opacity));
-}
-      .bg-opacity-50 {
-	--tw-bg-opacity: 0.5;
-}
-      .object-contain {
-	object-fit: contain;
-}
-      .object-cover {
-	object-fit: cover;
-}
-      .p-1\.5 {
-	padding: 0.375rem;
-}
-      .p-1 {
-	padding: 0.25rem;
-}
-      .p-3 {
-	padding: 0.75rem;
-}
-      .p-2 {
-	padding: 0.5rem;
-}
-      .p-6 {
-	padding: 1.5rem;
-}
-      .px-4 {
-	padding-left: 1rem;
-	padding-right: 1rem;
-}
-      .py-8 {
-	padding-top: 2rem;
-	padding-bottom: 2rem;
-}
-      .py-16 {
-	padding-top: 4rem;
-	padding-bottom: 4rem;
-}
-      .px-2 {
-	padding-left: 0.5rem;
-	padding-right: 0.5rem;
-}
-      .px-5 {
-	padding-left: 1.25rem;
-	padding-right: 1.25rem;
-}
-      .py-6 {
-	padding-top: 1.5rem;
-	padding-bottom: 1.5rem;
-}
-      .px-6 {
-	padding-left: 1.5rem;
-	padding-right: 1.5rem;
-}
-      .px-8 {
-	padding-left: 2rem;
-	padding-right: 2rem;
-}
-      .py-4 {
-	padding-top: 1rem;
-	padding-bottom: 1rem;
-}
-      .py-2 {
-	padding-top: 0.5rem;
-	padding-bottom: 0.5rem;
-}
-      .py-3 {
-	padding-top: 0.75rem;
-	padding-bottom: 0.75rem;
-}
-      .px-3 {
-	padding-left: 0.75rem;
-	padding-right: 0.75rem;
-}
-      .py-5 {
-	padding-top: 1.25rem;
-	padding-bottom: 1.25rem;
-}
-      .pb-6 {
-	padding-bottom: 1.5rem;
-}
-      .pt-5 {
-	padding-top: 1.25rem;
-}
-      .pb-8 {
-	padding-bottom: 2rem;
-}
-      .text-center {
-	text-align: center;
-}
-      .text-left {
-	text-align: left;
-}
-      .align-middle {
-	vertical-align: middle;
-}
-      .text-lg {
-	font-size: 1.125rem;
-	line-height: 1.75rem;
-}
-      .text-3xl {
-	font-size: 1.875rem;
-	line-height: 2.25rem;
-}
-      .text-base {
-	font-size: 1rem;
-	line-height: 1.5rem;
-}
-      .text-xl {
-	font-size: 1.25rem;
-	line-height: 1.75rem;
-}
-      .text-4xl {
-	font-size: 2.25rem;
-	line-height: 2.5rem;
-}
-      .text-sm {
-	font-size: 0.875rem;
-	line-height: 1.25rem;
-}
-      .text-xs {
-	font-size: 0.75rem;
-	line-height: 1rem;
-}
-      .font-extrabold {
-	font-weight: 800;
-}
-      .font-semibold {
-	font-weight: 600;
-}
-      .font-medium {
-	font-weight: 500;
-}
-      .uppercase {
-	text-transform: uppercase;
-}
-      .leading-8 {
-	line-height: 2rem;
-}
-      .leading-5 {
-	line-height: 1.25rem;
-}
-      .leading-6 {
-	line-height: 1.5rem;
-}
-      .tracking-tight {
-	letter-spacing: -0.025em;
-}
-      .tracking-wide {
-	letter-spacing: 0.025em;
-}
-      .tracking-wider {
-	letter-spacing: 0.05em;
-}
-      .text-gray-900 {
-	--tw-text-opacity: 1;
-	color: rgba(17, 24, 39, var(--tw-text-opacity));
-}
-      .text-gray-500 {
-	--tw-text-opacity: 1;
-	color: rgba(107, 114, 128, var(--tw-text-opacity));
-}
-      .text-indigo-600 {
-	--tw-text-opacity: 1;
-	color: rgba(79, 70, 229, var(--tw-text-opacity));
-}
-      .text-gray-400 {
-	--tw-text-opacity: 1;
-	color: rgba(156, 163, 175, var(--tw-text-opacity));
-}
-      .text-gray-600 {
-	--tw-text-opacity: 1;
-	color: rgba(75, 85, 99, var(--tw-text-opacity));
-}
-      .text-white {
-	--tw-text-opacity: 1;
-	color: rgba(255, 255, 255, var(--tw-text-opacity));
-}
-      .text-black {
-	--tw-text-opacity: 1;
-	color: rgba(0, 0, 0, var(--tw-text-opacity));
-}
-      .text-green-800 {
-	--tw-text-opacity: 1;
-	color: rgba(6, 95, 70, var(--tw-text-opacity));
-}
-      .text-orangedark {
-	--tw-text-opacity: 1;
-	color: rgba(237, 113, 9, var(--tw-text-opacity));
-}
-      .text-gray-700 {
-	--tw-text-opacity: 1;
-	color: rgba(55, 65, 81, var(--tw-text-opacity));
-}
-      .antialiased {
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
-}
-      .opacity-0 {
-	opacity: 0;
-}
-      .opacity-100 {
-	opacity: 1;
-}
-      .shadow-lg {
-	--tw-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
-	box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-}
-      .shadow {
-	--tw-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-	box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-}
-      .ring-1 {
-	--tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
-	--tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
-	box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
-}
-      .ring-8 {
-	--tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
-	--tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(8px + var(--tw-ring-offset-width)) var(--tw-ring-color);
-	box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
-}
-      .ring-black {
-	--tw-ring-opacity: 1;
-	--tw-ring-color: rgba(0, 0, 0, var(--tw-ring-opacity));
-}
-      .ring-white {
-	--tw-ring-opacity: 1;
-	--tw-ring-color: rgba(255, 255, 255, var(--tw-ring-opacity));
-}
-      .ring-opacity-5 {
-	--tw-ring-opacity: 0.05;
-}
-      .filter {
-	--tw-blur: var(--tw-empty,/*!*/ /*!*/);
-	--tw-brightness: var(--tw-empty,/*!*/ /*!*/);
-	--tw-contrast: var(--tw-empty,/*!*/ /*!*/);
-	--tw-grayscale: var(--tw-empty,/*!*/ /*!*/);
-	--tw-hue-rotate: var(--tw-empty,/*!*/ /*!*/);
-	--tw-invert: var(--tw-empty,/*!*/ /*!*/);
-	--tw-saturate: var(--tw-empty,/*!*/ /*!*/);
-	--tw-sepia: var(--tw-empty,/*!*/ /*!*/);
-	--tw-drop-shadow: var(--tw-empty,/*!*/ /*!*/);
-	filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
-}
-      .grayscale {
-	--tw-grayscale: grayscale(100%);
-}
-      .transition {
-	transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
-	transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
-	transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
-	transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-	transition-duration: 150ms;
-}
-      .duration-200 {
-	transition-duration: 200ms;
-}
-      .duration-150 {
-	transition-duration: 150ms;
-}
-      .duration-100 {
-	transition-duration: 100ms;
-}
-      .duration-300 {
-	transition-duration: 300ms;
-}
-      .ease-out {
-	transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
-}
-      .ease-in {
-	transition-timing-function: cubic-bezier(0.4, 0, 1, 1);
-}
-      .ease-in-out {
-	transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-}
-      .hover\:bg-gray-50:hover {
-	--tw-bg-opacity: 1;
-	background-color: rgba(249, 250, 251, var(--tw-bg-opacity));
-}
-      .hover\:bg-gray-100:hover {
-	--tw-bg-opacity: 1;
-	background-color: rgba(243, 244, 246, var(--tw-bg-opacity));
-}
-      .hover\:text-gray-900:hover {
-	--tw-text-opacity: 1;
-	color: rgba(17, 24, 39, var(--tw-text-opacity));
-}
-      .hover\:text-gray-500:hover {
-	--tw-text-opacity: 1;
-	color: rgba(107, 114, 128, var(--tw-text-opacity));
-}
-      .hover\:underline:hover {
-	text-decoration: underline;
-}
-      .hover\:filter-none:hover {
-	filter: none;
-}
-      .focus\:outline-none:focus {
-	outline: 2px solid transparent;
-	outline-offset: 2px;
-}
-      .focus\:ring-2:focus {
-	--tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
-	--tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
-	box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
-}
-      .focus\:ring-inset:focus {
-	--tw-ring-inset: inset;
-}
-      .focus\:ring-indigo-500:focus {
-	--tw-ring-opacity: 1;
-	--tw-ring-color: rgba(99, 102, 241, var(--tw-ring-opacity));
-}
-      .focus\:ring-offset-2:focus {
-	--tw-ring-offset-width: 2px;
-}
-      .group:hover .group-hover\:text-gray-500 {
-	--tw-text-opacity: 1;
-	color: rgba(107, 114, 128, var(--tw-text-opacity));
-}
-      @media (prefers-reduced-motion: no-preference) {
 
-	.motion-safe\:ease-out {
-		transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
-	}
+.aspect-w-3 {
+  --tw-aspect-w: 3;
 }
-      @media (min-width: 640px) {
 
-	.sm\:aspect-w-1,
+.aspect-h-2 {
+  --tw-aspect-h: 2;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+.pointer-events-none {
+  pointer-events: none;
+}
+
+.fixed {
+  position: fixed;
+}
+
+.absolute {
+  position: absolute;
+}
+
+.relative {
+  position: relative;
+}
+
+.inset-0 {
+  top: 0px;
+  right: 0px;
+  bottom: 0px;
+  left: 0px;
+}
+
+.inset-x-0 {
+  left: 0px;
+  right: 0px;
+}
+
+.left-1\/2 {
+  left: 50%;
+}
+
+.top-0 {
+  top: 0px;
+}
+
+.top-7 {
+  top: 1.75rem;
+}
+
+.left-7 {
+  left: 1.75rem;
+}
+
+.z-10 {
+  z-index: 10;
+}
+
+.z-30 {
+  z-index: 30;
+}
+
+.z-50 {
+  z-index: 50;
+}
+
+.col-span-1 {
+  grid-column: span 1 / span 1;
+}
+
+.-m-3 {
+  margin: -0.75rem;
+}
+
+.mx-auto {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.-my-2 {
+  margin-top: -0.5rem;
+  margin-bottom: -0.5rem;
+}
+
+.mt-2 {
+  margin-top: 0.5rem;
+}
+
+.mt-6 {
+  margin-top: 1.5rem;
+}
+
+.mt-5 {
+  margin-top: 1.25rem;
+}
+
+.mt-1 {
+  margin-top: 0.25rem;
+}
+
+.ml-2 {
+  margin-left: 0.5rem;
+}
+
+.mt-3 {
+  margin-top: 0.75rem;
+}
+
+.-mr-2 {
+  margin-right: -0.5rem;
+}
+
+.ml-4 {
+  margin-left: 1rem;
+}
+
+.mt-12 {
+  margin-top: 3rem;
+}
+
+.-mb-8 {
+  margin-bottom: -2rem;
+}
+
+.-ml-px {
+  margin-left: -1px;
+}
+
+.mt-0\.5 {
+  margin-top: 0.125rem;
+}
+
+.mt-0 {
+  margin-top: 0px;
+}
+
+.mt-8 {
+  margin-top: 2rem;
+}
+
+.block {
+  display: block;
+}
+
+.inline-block {
+  display: inline-block;
+}
+
+.flex {
+  display: flex;
+}
+
+.inline-flex {
+  display: inline-flex;
+}
+
+.table {
+  display: table;
+}
+
+.flow-root {
+  display: flow-root;
+}
+
+.grid {
+  display: grid;
+}
+
+.hidden {
+  display: none;
+}
+
+.h-5 {
+  height: 1.25rem;
+}
+
+.h-8 {
+  height: 2rem;
+}
+
+.h-6 {
+  height: 1.5rem;
+}
+
+.h-10 {
+  height: 2.5rem;
+}
+
+.h-48 {
+  height: 12rem;
+}
+
+.h-full {
+  height: 100%;
+}
+
+.h-14 {
+  height: 3.5rem;
+}
+
+.w-5 {
+  width: 1.25rem;
+}
+
+.w-screen {
+  width: 100vw;
+}
+
+.w-auto {
+  width: auto;
+}
+
+.w-6 {
+  width: 1.5rem;
+}
+
+.w-10 {
+  width: 2.5rem;
+}
+
+.w-full {
+  width: 100%;
+}
+
+.w-0\.5 {
+  width: 0.125rem;
+}
+
+.w-0 {
+  width: 0px;
+}
+
+.w-14 {
+  width: 3.5rem;
+}
+
+.min-w-full {
+  min-width: 100%;
+}
+
+.min-w-0 {
+  min-width: 0px;
+}
+
+.max-w-prose {
+  max-width: 65ch;
+}
+
+.max-w-md {
+  max-width: 28rem;
+}
+
+.max-w-xl {
+  max-width: 36rem;
+}
+
+.max-w-7xl {
+  max-width: 80rem;
+}
+
+.max-w-xs {
+  max-width: 20rem;
+}
+
+.max-w-3xl {
+  max-width: 48rem;
+}
+
+.max-w-none {
+  max-width: none;
+}
+
+.max-w-lg {
+  max-width: 32rem;
+}
+
+.max-w-6xl {
+  max-width: 72rem;
+}
+
+.max-w-2xl {
+  max-width: 42rem;
+}
+
+.max-w-full {
+  max-width: 100%;
+}
+
+.flex-1 {
+  flex: 1 1 0%;
+}
+
+.flex-shrink-0 {
+  flex-shrink: 0;
+}
+
+.origin-top-right {
+  transform-origin: top right;
+}
+
+.translate-y-1 {
+  --tw-translate-y: 0.25rem;
+  transform: var(--tw-transform);
+}
+
+.translate-y-0 {
+  --tw-translate-y: 0px;
+  transform: var(--tw-transform);
+}
+
+.-translate-x-1\/2 {
+  --tw-translate-x: -50%;
+  transform: var(--tw-transform);
+}
+
+.scale-95 {
+  --tw-scale-x: .95;
+  --tw-scale-y: .95;
+  transform: var(--tw-transform);
+}
+
+.scale-100 {
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  transform: var(--tw-transform);
+}
+
+.scale-90 {
+  --tw-scale-x: .9;
+  --tw-scale-y: .9;
+  transform: var(--tw-transform);
+}
+
+.transform {
+  transform: var(--tw-transform);
+}
+
+.cursor-pointer {
+  cursor: pointer;
+}
+
+.grid-cols-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.grid-cols-1 {
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+.flex-col {
+  flex-direction: column;
+}
+
+.items-start {
+  align-items: flex-start;
+}
+
+.items-center {
+  align-items: center;
+}
+
+.justify-center {
+  justify-content: center;
+}
+
+.justify-between {
+  justify-content: space-between;
+}
+
+.gap-6 {
+  gap: 1.5rem;
+}
+
+.gap-0\.5 {
+  gap: 0.125rem;
+}
+
+.gap-0 {
+  gap: 0px;
+}
+
+.gap-5 {
+  gap: 1.25rem;
+}
+
+.gap-x-4 {
+  -moz-column-gap: 1rem;
+       column-gap: 1rem;
+}
+
+.gap-y-8 {
+  row-gap: 2rem;
+}
+
+.space-y-8 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(2rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(2rem * var(--tw-space-y-reverse));
+}
+
+.space-y-4 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(1rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(1rem * var(--tw-space-y-reverse));
+}
+
+.space-x-10 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(2.5rem * var(--tw-space-x-reverse));
+  margin-left: calc(2.5rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-3 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(0.75rem * var(--tw-space-x-reverse));
+  margin-left: calc(0.75rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-y-1 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0.25rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0.25rem * var(--tw-space-y-reverse));
+}
+
+.divide-y-2 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-y-reverse: 0;
+  border-top-width: calc(2px * calc(1 - var(--tw-divide-y-reverse)));
+  border-bottom-width: calc(2px * var(--tw-divide-y-reverse));
+}
+
+.divide-y > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-y-reverse: 0;
+  border-top-width: calc(1px * calc(1 - var(--tw-divide-y-reverse)));
+  border-bottom-width: calc(1px * var(--tw-divide-y-reverse));
+}
+
+.divide-gray-50 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 1;
+  border-color: rgba(249, 250, 251, var(--tw-divide-opacity));
+}
+
+.divide-gray-200 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 1;
+  border-color: rgba(229, 231, 235, var(--tw-divide-opacity));
+}
+
+.overflow-auto {
+  overflow: auto;
+}
+
+.overflow-hidden {
+  overflow: hidden;
+}
+
+.overflow-x-auto {
+  overflow-x: auto;
+}
+
+.truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rounded-lg {
+  border-radius: 0.5rem;
+}
+
+.rounded-md {
+  border-radius: 0.375rem;
+}
+
+.rounded {
+  border-radius: 0.25rem;
+}
+
+.rounded-full {
+  border-radius: 9999px;
+}
+
+.border-b {
+  border-bottom-width: 1px;
+}
+
+.border-t {
+  border-top-width: 1px;
+}
+
+.border-gray-200 {
+  --tw-border-opacity: 1;
+  border-color: rgba(229, 231, 235, var(--tw-border-opacity));
+}
+
+.bg-white {
+  --tw-bg-opacity: 1;
+  background-color: rgba(255, 255, 255, var(--tw-bg-opacity));
+}
+
+.bg-indigo-500 {
+  --tw-bg-opacity: 1;
+  background-color: rgba(99, 102, 241, var(--tw-bg-opacity));
+}
+
+.bg-gray-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgba(229, 231, 235, var(--tw-bg-opacity));
+}
+
+.bg-black {
+  --tw-bg-opacity: 1;
+  background-color: rgba(0, 0, 0, var(--tw-bg-opacity));
+}
+
+.bg-graylight {
+  --tw-bg-opacity: 1;
+  background-color: rgba(245, 245, 245, var(--tw-bg-opacity));
+}
+
+.bg-green-100 {
+  --tw-bg-opacity: 1;
+  background-color: rgba(209, 250, 229, var(--tw-bg-opacity));
+}
+
+.bg-gray-50 {
+  --tw-bg-opacity: 1;
+  background-color: rgba(249, 250, 251, var(--tw-bg-opacity));
+}
+
+.bg-blue-400 {
+  --tw-bg-opacity: 1;
+  background-color: rgba(96, 165, 250, var(--tw-bg-opacity));
+}
+
+.bg-green-400 {
+  --tw-bg-opacity: 1;
+  background-color: rgba(52, 211, 153, var(--tw-bg-opacity));
+}
+
+.bg-pink-400 {
+  --tw-bg-opacity: 1;
+  background-color: rgba(244, 114, 182, var(--tw-bg-opacity));
+}
+
+.bg-red-400 {
+  --tw-bg-opacity: 1;
+  background-color: rgba(248, 113, 113, var(--tw-bg-opacity));
+}
+
+.bg-opacity-50 {
+  --tw-bg-opacity: 0.5;
+}
+
+.object-contain {
+  -o-object-fit: contain;
+     object-fit: contain;
+}
+
+.object-cover {
+  -o-object-fit: cover;
+     object-fit: cover;
+}
+
+.p-1\.5 {
+  padding: 0.375rem;
+}
+
+.p-1 {
+  padding: 0.25rem;
+}
+
+.p-3 {
+  padding: 0.75rem;
+}
+
+.p-2 {
+  padding: 0.5rem;
+}
+
+.p-6 {
+  padding: 1.5rem;
+}
+
+.px-4 {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.py-8 {
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+}
+
+.py-16 {
+  padding-top: 4rem;
+  padding-bottom: 4rem;
+}
+
+.px-2 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.px-5 {
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
+}
+
+.py-6 {
+  padding-top: 1.5rem;
+  padding-bottom: 1.5rem;
+}
+
+.px-6 {
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+}
+
+.px-8 {
+  padding-left: 2rem;
+  padding-right: 2rem;
+}
+
+.py-4 {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+
+.py-2 {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+
+.py-3 {
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+}
+
+.px-3 {
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+}
+
+.py-5 {
+  padding-top: 1.25rem;
+  padding-bottom: 1.25rem;
+}
+
+.pb-6 {
+  padding-bottom: 1.5rem;
+}
+
+.pt-5 {
+  padding-top: 1.25rem;
+}
+
+.pb-8 {
+  padding-bottom: 2rem;
+}
+
+.text-left {
+  text-align: left;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.align-middle {
+  vertical-align: middle;
+}
+
+.text-lg {
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+}
+
+.text-3xl {
+  font-size: 1.875rem;
+  line-height: 2.25rem;
+}
+
+.text-base {
+  font-size: 1rem;
+  line-height: 1.5rem;
+}
+
+.text-xl {
+  font-size: 1.25rem;
+  line-height: 1.75rem;
+}
+
+.text-4xl {
+  font-size: 2.25rem;
+  line-height: 2.5rem;
+}
+
+.text-sm {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+
+.text-xs {
+  font-size: 0.75rem;
+  line-height: 1rem;
+}
+
+.font-extrabold {
+  font-weight: 800;
+}
+
+.font-semibold {
+  font-weight: 600;
+}
+
+.font-medium {
+  font-weight: 500;
+}
+
+.uppercase {
+  text-transform: uppercase;
+}
+
+.leading-8 {
+  line-height: 2rem;
+}
+
+.leading-5 {
+  line-height: 1.25rem;
+}
+
+.leading-6 {
+  line-height: 1.5rem;
+}
+
+.tracking-tight {
+  letter-spacing: -0.025em;
+}
+
+.tracking-wide {
+  letter-spacing: 0.025em;
+}
+
+.tracking-wider {
+  letter-spacing: 0.05em;
+}
+
+.text-gray-900 {
+  --tw-text-opacity: 1;
+  color: rgba(17, 24, 39, var(--tw-text-opacity));
+}
+
+.text-gray-500 {
+  --tw-text-opacity: 1;
+  color: rgba(107, 114, 128, var(--tw-text-opacity));
+}
+
+.text-indigo-600 {
+  --tw-text-opacity: 1;
+  color: rgba(79, 70, 229, var(--tw-text-opacity));
+}
+
+.text-gray-400 {
+  --tw-text-opacity: 1;
+  color: rgba(156, 163, 175, var(--tw-text-opacity));
+}
+
+.text-gray-600 {
+  --tw-text-opacity: 1;
+  color: rgba(75, 85, 99, var(--tw-text-opacity));
+}
+
+.text-white {
+  --tw-text-opacity: 1;
+  color: rgba(255, 255, 255, var(--tw-text-opacity));
+}
+
+.text-black {
+  --tw-text-opacity: 1;
+  color: rgba(0, 0, 0, var(--tw-text-opacity));
+}
+
+.text-green-800 {
+  --tw-text-opacity: 1;
+  color: rgba(6, 95, 70, var(--tw-text-opacity));
+}
+
+.text-orangedark {
+  --tw-text-opacity: 1;
+  color: rgba(237, 113, 9, var(--tw-text-opacity));
+}
+
+.text-gray-700 {
+  --tw-text-opacity: 1;
+  color: rgba(55, 65, 81, var(--tw-text-opacity));
+}
+
+.antialiased {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.opacity-0 {
+  opacity: 0;
+}
+
+.opacity-100 {
+  opacity: 1;
+}
+
+.shadow-lg {
+  --tw-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow {
+  --tw-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.ring-1 {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.ring-8 {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(8px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.ring-black {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(0, 0, 0, var(--tw-ring-opacity));
+}
+
+.ring-white {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(255, 255, 255, var(--tw-ring-opacity));
+}
+
+.ring-opacity-5 {
+  --tw-ring-opacity: 0.05;
+}
+
+.grayscale {
+  --tw-grayscale: grayscale(100%);
+  filter: var(--tw-filter);
+}
+
+.filter {
+  filter: var(--tw-filter);
+}
+
+.transition {
+  transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
+  transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
+  transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.duration-200 {
+  transition-duration: 200ms;
+}
+
+.duration-150 {
+  transition-duration: 150ms;
+}
+
+.duration-100 {
+  transition-duration: 100ms;
+}
+
+.duration-300 {
+  transition-duration: 300ms;
+}
+
+.ease-out {
+  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+}
+
+.ease-in {
+  transition-timing-function: cubic-bezier(0.4, 0, 1, 1);
+}
+
+.ease-in-out {
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.hover\:bg-gray-50:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgba(249, 250, 251, var(--tw-bg-opacity));
+}
+
+.hover\:bg-gray-100:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgba(243, 244, 246, var(--tw-bg-opacity));
+}
+
+.hover\:text-gray-900:hover {
+  --tw-text-opacity: 1;
+  color: rgba(17, 24, 39, var(--tw-text-opacity));
+}
+
+.hover\:text-gray-500:hover {
+  --tw-text-opacity: 1;
+  color: rgba(107, 114, 128, var(--tw-text-opacity));
+}
+
+.hover\:underline:hover {
+  text-decoration: underline;
+}
+
+.hover\:filter-none:hover {
+  filter: none;
+}
+
+.focus\:outline-none:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+.focus\:ring-2:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus\:ring-inset:focus {
+  --tw-ring-inset: inset;
+}
+
+.focus\:ring-indigo-500:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(99, 102, 241, var(--tw-ring-opacity));
+}
+
+.focus\:ring-offset-2:focus {
+  --tw-ring-offset-width: 2px;
+}
+
+.group:hover .group-hover\:text-gray-500 {
+  --tw-text-opacity: 1;
+  color: rgba(107, 114, 128, var(--tw-text-opacity));
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .motion-safe\:ease-out {
+    transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+  }
+}
+
+@media (min-width: 640px) {
+  .sm\:aspect-w-1,
 .sm\:aspect-w-2,
 .sm\:aspect-w-3,
 .sm\:aspect-w-4,
@@ -2003,11 +2419,11 @@ select {
 .sm\:aspect-w-14,
 .sm\:aspect-w-15,
 .sm\:aspect-w-16 {
-		position: relative;
-		padding-bottom: calc(var(--tw-aspect-h) / var(--tw-aspect-w) * 100%);
-	}
+    position: relative;
+    padding-bottom: calc(var(--tw-aspect-h) / var(--tw-aspect-w) * 100%);
+  }
 
-	.sm\:aspect-w-1 > *,
+  .sm\:aspect-w-1 > *,
 .sm\:aspect-w-2 > *,
 .sm\:aspect-w-3 > *,
 .sm\:aspect-w-4 > *,
@@ -2023,235 +2439,236 @@ select {
 .sm\:aspect-w-14 > *,
 .sm\:aspect-w-15 > *,
 .sm\:aspect-w-16 > * {
-		position: absolute;
-		height: 100%;
-		width: 100%;
-		top: 0;
-		right: 0;
-		bottom: 0;
-		left: 0;
-	}
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  }
 
-	.sm\:aspect-w-3 {
-		--tw-aspect-w: 3;
-	}
+  .sm\:aspect-w-3 {
+    --tw-aspect-w: 3;
+  }
 
-	.sm\:aspect-h-4 {
-		--tw-aspect-h: 4;
-	}
+  .sm\:aspect-h-4 {
+    --tw-aspect-h: 4;
+  }
 
-	.sm\:col-span-4 {
-		grid-column: span 4 / span 4;
-	}
+  .sm\:col-span-4 {
+    grid-column: span 4 / span 4;
+  }
 
-	.sm\:-mx-6 {
-		margin-left: -1.5rem;
-		margin-right: -1.5rem;
-	}
+  .sm\:-mx-6 {
+    margin-left: -1.5rem;
+    margin-right: -1.5rem;
+  }
 
-	.sm\:grid {
-		display: grid;
-	}
+  .sm\:grid {
+    display: grid;
+  }
 
-	.sm\:h-10 {
-		height: 2.5rem;
-	}
+  .sm\:h-10 {
+    height: 2.5rem;
+  }
 
-	.sm\:max-w-3xl {
-		max-width: 48rem;
-	}
+  .sm\:max-w-3xl {
+    max-width: 48rem;
+  }
 
-	.sm\:grid-cols-5 {
-		grid-template-columns: repeat(5, minmax(0, 1fr));
-	}
+  .sm\:grid-cols-5 {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
 
-	.sm\:grid-cols-2 {
-		grid-template-columns: repeat(2, minmax(0, 1fr));
-	}
+  .sm\:grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 
-	.sm\:items-start {
-		align-items: flex-start;
-	}
+  .sm\:items-start {
+    align-items: flex-start;
+  }
 
-	.sm\:gap-6 {
-		gap: 1.5rem;
-	}
+  .sm\:gap-6 {
+    gap: 1.5rem;
+  }
 
-	.sm\:gap-8 {
-		gap: 2rem;
-	}
+  .sm\:gap-8 {
+    gap: 2rem;
+  }
 
-	.sm\:gap-x-6 {
-		column-gap: 1.5rem;
-	}
+  .sm\:gap-x-6 {
+    -moz-column-gap: 1.5rem;
+         column-gap: 1.5rem;
+  }
 
-	.sm\:space-y-0 > :not([hidden]) ~ :not([hidden]) {
-		--tw-space-y-reverse: 0;
-		margin-top: calc(0px * calc(1 - var(--tw-space-y-reverse)));
-		margin-bottom: calc(0px * var(--tw-space-y-reverse));
-	}
+  .sm\:space-y-0 > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(0px * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(0px * var(--tw-space-y-reverse));
+  }
 
-	.sm\:rounded-lg {
-		border-radius: 0.5rem;
-	}
+  .sm\:rounded-lg {
+    border-radius: 0.5rem;
+  }
 
-	.sm\:rounded-md {
-		border-radius: 0.375rem;
-	}
+  .sm\:rounded-md {
+    border-radius: 0.375rem;
+  }
 
-	.sm\:p-8 {
-		padding: 2rem;
-	}
+  .sm\:p-8 {
+    padding: 2rem;
+  }
 
-	.sm\:px-6 {
-		padding-left: 1.5rem;
-		padding-right: 1.5rem;
-	}
+  .sm\:px-6 {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
 
-	.sm\:py-24 {
-		padding-top: 6rem;
-		padding-bottom: 6rem;
-	}
+  .sm\:py-24 {
+    padding-top: 6rem;
+    padding-bottom: 6rem;
+  }
 
-	.sm\:px-0 {
-		padding-left: 0px;
-		padding-right: 0px;
-	}
+  .sm\:px-0 {
+    padding-left: 0px;
+    padding-right: 0px;
+  }
 
-	.sm\:text-4xl {
-		font-size: 2.25rem;
-		line-height: 2.5rem;
-	}
+  .sm\:text-4xl {
+    font-size: 2.25rem;
+    line-height: 2.5rem;
+  }
 
-	.sm\:text-5xl {
-		font-size: 3rem;
-		line-height: 1;
-	}
+  .sm\:text-5xl {
+    font-size: 3rem;
+    line-height: 1;
+  }
 
-	.sm\:text-xl {
-		font-size: 1.25rem;
-		line-height: 1.75rem;
-	}
+  .sm\:text-xl {
+    font-size: 1.25rem;
+    line-height: 1.75rem;
+  }
 
-	.sm\:tracking-tight {
-		letter-spacing: -0.025em;
-	}
+  .sm\:tracking-tight {
+    letter-spacing: -0.025em;
+  }
 }
-      @media (min-width: 768px) {
 
-	.md\:flex {
-		display: flex;
-	}
+@media (min-width: 768px) {
+  .md\:flex {
+    display: flex;
+  }
 
-	.md\:grid {
-		display: grid;
-	}
+  .md\:grid {
+    display: grid;
+  }
 
-	.md\:hidden {
-		display: none;
-	}
+  .md\:hidden {
+    display: none;
+  }
 
-	.md\:flex-1 {
-		flex: 1 1 0%;
-	}
+  .md\:flex-1 {
+    flex: 1 1 0%;
+  }
 
-	.md\:grid-cols-3 {
-		grid-template-columns: repeat(3, minmax(0, 1fr));
-	}
+  .md\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
 
-	.md\:grid-cols-2 {
-		grid-template-columns: repeat(2, minmax(0, 1fr));
-	}
+  .md\:grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 
-	.md\:items-center {
-		align-items: center;
-	}
+  .md\:items-center {
+    align-items: center;
+  }
 
-	.md\:justify-start {
-		justify-content: flex-start;
-	}
+  .md\:justify-start {
+    justify-content: flex-start;
+  }
 
-	.md\:justify-between {
-		justify-content: space-between;
-	}
+  .md\:justify-between {
+    justify-content: space-between;
+  }
 
-	.md\:gap-4 {
-		gap: 1rem;
-	}
+  .md\:gap-4 {
+    gap: 1rem;
+  }
 
-	.md\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
-		--tw-space-x-reverse: 0;
-		margin-right: calc(2.5rem * var(--tw-space-x-reverse));
-		margin-left: calc(2.5rem * calc(1 - var(--tw-space-x-reverse)));
-	}
+  .md\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(2.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(2.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
 
-	.md\:text-xl {
-		font-size: 1.25rem;
-		line-height: 1.75rem;
-	}
+  .md\:text-xl {
+    font-size: 1.25rem;
+    line-height: 1.75rem;
+  }
 }
-      @media (min-width: 1024px) {
 
-	.lg\:col-span-1 {
-		grid-column: span 1 / span 1;
-	}
+@media (min-width: 1024px) {
+  .lg\:col-span-1 {
+    grid-column: span 1 / span 1;
+  }
 
-	.lg\:col-span-3 {
-		grid-column: span 3 / span 3;
-	}
+  .lg\:col-span-3 {
+    grid-column: span 3 / span 3;
+  }
 
-	.lg\:col-start-2 {
-		grid-column-start: 2;
-	}
+  .lg\:col-start-2 {
+    grid-column-start: 2;
+  }
 
-	.lg\:-mx-8 {
-		margin-left: -2rem;
-		margin-right: -2rem;
-	}
+  .lg\:-mx-8 {
+    margin-left: -2rem;
+    margin-right: -2rem;
+  }
 
-	.lg\:mt-8 {
-		margin-top: 2rem;
-	}
+  .lg\:mt-8 {
+    margin-top: 2rem;
+  }
 
-	.lg\:max-w-7xl {
-		max-width: 80rem;
-	}
+  .lg\:max-w-7xl {
+    max-width: 80rem;
+  }
 
-	.lg\:max-w-none {
-		max-width: none;
-	}
+  .lg\:max-w-none {
+    max-width: none;
+  }
 
-	.lg\:grid-flow-col-dense {
-		grid-auto-flow: column dense;
-	}
+  .lg\:grid-flow-col-dense {
+    grid-auto-flow: column dense;
+  }
 
-	.lg\:grid-cols-3 {
-		grid-template-columns: repeat(3, minmax(0, 1fr));
-	}
+  .lg\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
 
-	.lg\:grid-cols-4 {
-		grid-template-columns: repeat(4, minmax(0, 1fr));
-	}
+  .lg\:grid-cols-4 {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
 
-	.lg\:px-8 {
-		padding-left: 2rem;
-		padding-right: 2rem;
-	}
+  .lg\:px-8 {
+    padding-left: 2rem;
+    padding-right: 2rem;
+  }
 
-	.lg\:py-32 {
-		padding-top: 8rem;
-		padding-bottom: 8rem;
-	}
+  .lg\:py-32 {
+    padding-top: 8rem;
+    padding-bottom: 8rem;
+  }
 
-	.lg\:text-6xl {
-		font-size: 3.75rem;
-		line-height: 1;
-	}
+  .lg\:text-6xl {
+    font-size: 3.75rem;
+    line-height: 1;
+  }
 }
-      @media (min-width: 1280px) {
 
-	.xl\:gap-x-8 {
-		column-gap: 2rem;
-	}
+@media (min-width: 1280px) {
+  .xl\:gap-x-8 {
+    -moz-column-gap: 2rem;
+         column-gap: 2rem;
+  }
 }
-    

--- a/src/ood-preview/lib/templates/watch_template.eml
+++ b/src/ood-preview/lib/templates/watch_template.eml
@@ -3,7 +3,7 @@ let render_watch (watch : Ood.Watch.t) =
   <li class="relative">
     <iframe class="bg-black mx-auto" x-ref="player" src="<%s "https://watch.ocaml.org" ^ watch.embedPath %>" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
     <p class="mt-2 block text-sm font-medium text-gray-900 truncate pointer-events-none"><%s watch.name %></p>
-    <p class="block text-sm font-medium text-gray-500 pointer-events-none truncate"><%s watch.description %></p>
+    <p class="block text-sm font-medium text-gray-500 pointer-events-none truncate"><%s Option.value ~default:"" watch.description %></p>
   </li>
 
 let render watch = 

--- a/src/ood-preview/lib/templates/watch_template.eml
+++ b/src/ood-preview/lib/templates/watch_template.eml
@@ -1,7 +1,7 @@
 let render_watch (watch : Ood.Watch.t) = 
   let open Ood.Watch in
   <li class="relative">
-    <iframe class="bg-black mx-auto" x-ref="player" src="<%s "https://watch.ocaml.org" ^ watch.embedPath %>" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+    <iframe class="bg-black mx-auto" x-ref="player" src="<%s "https://watch.ocaml.org" ^ watch.embed_path %>" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
     <p class="mt-2 block text-sm font-medium text-gray-900 truncate pointer-events-none"><%s watch.name %></p>
     <p class="block text-sm font-medium text-gray-500 pointer-events-none truncate"><%s Option.value ~default:"" watch.description %></p>
   </li>

--- a/src/ood/ood.mli
+++ b/src/ood/ood.mli
@@ -205,8 +205,8 @@ module Watch : sig
     name : string;
     embedPath : string;
     thumbnailPath : string;
-    description : string;
-    year : int;
+    description : string option;
+    date : string;
     language : string;
     category : string;
   }

--- a/src/ood/ood.mli
+++ b/src/ood/ood.mli
@@ -203,10 +203,11 @@ end
 module Watch : sig
   type t = {
     name : string;
-    embedPath : string;
-    thumbnailPath : string;
+    embed_path : string;
+    thumbnail_path : string;
     description : string option;
-    date : string;
+    published_at : string;
+    updated_at : string;
     language : string;
     category : string;
   }

--- a/src/ood/watch.ml
+++ b/src/ood/watch.ml
@@ -2,10 +2,11 @@
 
   type t =
   { name: string;
-    embedPath : string;
-    thumbnailPath : string;
+    embed_path : string;
+    thumbnail_path : string;
     description : string option;
-    date : string;
+    published_at : string;
+    updated_at : string;
     language : string;
     category : string;
   }
@@ -13,249 +14,275 @@
 let all = 
 [
   { name = {js|25 Years of OCaml: Xavier Leroy|js}
-  ; embedPath = {js|/videos/embed/e1ee0fc0-50ef-4a1c-894a-17df181424cb|js}
-  ; thumbnailPath = {js|/static/thumbnails/94ead657-79a0-4c10-8435-9e13906a6c44.jpg|js}
+  ; embed_path = {js|/videos/embed/e1ee0fc0-50ef-4a1c-894a-17df181424cb|js}
+  ; thumbnail_path = {js|/static/thumbnails/94ead657-79a0-4c10-8435-9e13906a6c44.jpg|js}
   ; description = Some {js|Professor Xavier Leroy -- the primary original author and leader of the OCaml project -- reflects on 25 years of the OCaml language at his OCaml Workshop 2021 keynote speech.|js}
-  ; date = {js|2021-08-27T13:23:10.199Z|js}
+  ; published_at = {js|2021-08-27T13:23:10.199Z|js}
+  ; updated_at = {js|2021-09-08T10:02:00.187Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
  
   { name = {js|A Declarative Syntax Definition for OCaml|js}
-  ; embedPath = {js|/videos/embed/a5b86864-8e43-4138-b6d6-ed48d2d4b63d|js}
-  ; thumbnailPath = {js|/static/thumbnails/92c0a0e3-5326-42aa-86a3-6adb3927e111.jpg|js}
+  ; embed_path = {js|/videos/embed/a5b86864-8e43-4138-b6d6-ed48d2d4b63d|js}
+  ; thumbnail_path = {js|/static/thumbnails/92c0a0e3-5326-42aa-86a3-6adb3927e111.jpg|js}
   ; description = Some {js|In this talk, we present our work on a syntax definition for the OCaml language in the syntax definition formalism SDF3. SDF3 supports the high-level definition of concrete and abstract syntax through declarative disambiguation and definition of c...|js}
-  ; date = {js|2020-08-28T00:00:00.000Z|js}
+  ; published_at = {js|2020-08-28T00:00:00.000Z|js}
+  ; updated_at = {js|2021-09-01T04:02:00.070Z|js}
   ; language = {js|Unknown|js}
   ; category = {js|Misc|js}
   };
  
   { name = {js|A Multiverse of Glorious Documentation|js}
-  ; embedPath = {js|/videos/embed/9bb452d6-1829-4dac-a6a2-46b31050c931|js}
-  ; thumbnailPath = {js|/static/thumbnails/6a0a8291-4626-4820-8071-904b3c508345.jpg|js}
+  ; embed_path = {js|/videos/embed/9bb452d6-1829-4dac-a6a2-46b31050c931|js}
+  ; thumbnail_path = {js|/static/thumbnails/6a0a8291-4626-4820-8071-904b3c508345.jpg|js}
   ; description = Some {js|This talk describes the process of generating documentation for every version of every package that can be built from the opam repository, and how it is presented as a single coherent website that is continuously updated as new packages are releas...|js}
-  ; date = {js|2021-08-27T11:23:36.000Z|js}
+  ; published_at = {js|2021-08-27T11:23:36.000Z|js}
+  ; updated_at = {js|2021-09-07T21:02:00.188Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
  
   { name = {js|A Simple State-Machine Framework for Property-Based Testing in OCaml|js}
-  ; embedPath = {js|/videos/embed/08b429ea-2eb8-427d-a625-5495f4ee0fef|js}
-  ; thumbnailPath = {js|/static/thumbnails/316ddad9-dbc3-4d46-9f43-5da72689e93b.jpg|js}
+  ; embed_path = {js|/videos/embed/08b429ea-2eb8-427d-a625-5495f4ee0fef|js}
+  ; thumbnail_path = {js|/static/thumbnails/316ddad9-dbc3-4d46-9f43-5da72689e93b.jpg|js}
   ; description = Some {js|Since their inception, state-machine frameworks have proven their worth by finding defects in everything from the underlying AUTOSAR components of Volvo cars to digital invoicing systems. These case studies were carried out with Erlang’s commercia...|js}
-  ; date = {js|2020-08-28T00:00:00.000Z|js}
+  ; published_at = {js|2020-08-28T00:00:00.000Z|js}
+  ; updated_at = {js|2021-05-21T15:08:00.099Z|js}
   ; language = {js|Unknown|js}
   ; category = {js|Misc|js}
   };
  
   { name = {js|A review of the growth of the OCaml community|js}
-  ; embedPath = {js|/videos/embed/f9d0b637-8aec-4bff-8c32-cd16b58023b6|js}
-  ; thumbnailPath = {js|/static/thumbnails/e573402b-1350-4aa7-a9ba-0e1c51198fb4.jpg|js}
+  ; embed_path = {js|/videos/embed/f9d0b637-8aec-4bff-8c32-cd16b58023b6|js}
+  ; thumbnail_path = {js|/static/thumbnails/e573402b-1350-4aa7-a9ba-0e1c51198fb4.jpg|js}
   ; description = None
-  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; published_at = {js|2015-09-18T00:00:00.000Z|js}
+  ; updated_at = {js|2021-08-03T17:05:33.471Z|js}
   ; language = {js|Unknown|js}
   ; category = {js|Science & Technology|js}
   };
  
   { name = {js|AD-OCaml: Algorithmic Differentiation for OCaml|js}
-  ; embedPath = {js|/videos/embed/c9e85690-732f-4b03-836f-2ee0fd8f0658|js}
-  ; thumbnailPath = {js|/static/thumbnails/eb972fd2-668e-4998-a798-e9fbdcadba20.jpg|js}
+  ; embed_path = {js|/videos/embed/c9e85690-732f-4b03-836f-2ee0fd8f0658|js}
+  ; thumbnail_path = {js|/static/thumbnails/eb972fd2-668e-4998-a798-e9fbdcadba20.jpg|js}
   ; description = Some {js|AD-OCaml is a library framework for calculating mathematically exact derivatives and deep power series approximations of almost arbitrary OCaml programs via algorithmic differentiation. Unlike similar frameworks, this includes programs with side e...|js}
-  ; date = {js|2020-08-28T00:00:00.000Z|js}
+  ; published_at = {js|2020-08-28T00:00:00.000Z|js}
+  ; updated_at = {js|2021-04-19T19:24:10.203Z|js}
   ; language = {js|Unknown|js}
   ; category = {js|Misc|js}
   };
  
   { name = {js|API migration: compare transformed|js}
-  ; embedPath = {js|/videos/embed/c46b925b-bd77-404f-ac5d-5dab65047529|js}
-  ; thumbnailPath = {js|/static/thumbnails/eef64419-3c34-4c15-9419-edcbc455e54d.jpg|js}
+  ; embed_path = {js|/videos/embed/c46b925b-bd77-404f-ac5d-5dab65047529|js}
+  ; thumbnail_path = {js|/static/thumbnails/eef64419-3c34-4c15-9419-edcbc455e54d.jpg|js}
   ; description = Some {js|In this talk we describe our experience in using an automatic API-migration strategy dedicated at changing the signatures of OCaml functions, using the Rotor refactoring tool for OCaml. We perform a case study on open source Jane Street libraries ...|js}
-  ; date = {js|2020-08-28T00:00:00.000Z|js}
+  ; published_at = {js|2020-08-28T00:00:00.000Z|js}
+  ; updated_at = {js|2021-09-01T14:02:00.083Z|js}
   ; language = {js|Unknown|js}
   ; category = {js|Misc|js}
   };
  
   { name = {js|Adapting the OCaml ecosystem for Multicore OCaml|js}
-  ; embedPath = {js|/videos/embed/629b89a8-bbd5-490d-98b0-d0c740912b02|js}
-  ; thumbnailPath = {js|/static/thumbnails/41212c84-36d6-44fa-b884-2ced79505929.jpg|js}
+  ; embed_path = {js|/videos/embed/629b89a8-bbd5-490d-98b0-d0c740912b02|js}
+  ; thumbnail_path = {js|/static/thumbnails/41212c84-36d6-44fa-b884-2ced79505929.jpg|js}
   ; description = Some {js|OCaml 5.0 with support for shared-memory parallelism being around the corner, there’s increasing interest in the community to port existing libraries to Multicore. This talk will take the attendees through what the arrival of Multicore means to th...|js}
-  ; date = {js|2021-08-27T10:18:38.000Z|js}
+  ; published_at = {js|2021-08-27T10:18:38.000Z|js}
+  ; updated_at = {js|2021-09-08T10:02:00.087Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
  
   { name = {js|Binary Analysis Platform|js}
-  ; embedPath = {js|/videos/embed/8dc2d8d3-c140-4c3d-a8fe-a6fcf6fba988|js}
-  ; thumbnailPath = {js|/static/thumbnails/390cd7dd-4578-4162-bae0-6c218cb5ebde.jpg|js}
+  ; embed_path = {js|/videos/embed/8dc2d8d3-c140-4c3d-a8fe-a6fcf6fba988|js}
+  ; thumbnail_path = {js|/static/thumbnails/390cd7dd-4578-4162-bae0-6c218cb5ebde.jpg|js}
   ; description = Some {js|We present Binary Analysis Platform (BAP), a representation-agnostic program analysis framework for binaries that can leverage existing tools, libraries, and frameworks, no matter which intermediate representation (IR) they use. In BAP, a new IR c...|js}
-  ; date = {js|2021-08-31T08:39:55.774Z|js}
+  ; published_at = {js|2021-08-31T08:39:55.774Z|js}
+  ; updated_at = {js|2021-09-04T14:02:00.212Z|js}
   ; language = {js|English|js}
   ; category = {js|Misc|js}
   };
  
   { name = {js|Continuous Benchmarking for OCaml Projects|js}
-  ; embedPath = {js|/videos/embed/1c994370-1aaa-4db6-b901-d762786e4904|js}
-  ; thumbnailPath = {js|/static/thumbnails/33ab36c3-3650-4c13-9fea-9b5907cf8c0f.jpg|js}
+  ; embed_path = {js|/videos/embed/1c994370-1aaa-4db6-b901-d762786e4904|js}
+  ; thumbnail_path = {js|/static/thumbnails/33ab36c3-3650-4c13-9fea-9b5907cf8c0f.jpg|js}
   ; description = Some {js|Regular CI systems are optimised for workloads that do not require stable performance over time. This makes them unsuitable for running performance benchmarks.
 
 current-bench provides a predictable environment for performance benchmarks and a UI...|js}
-  ; date = {js|2021-08-27T11:20:09.000Z|js}
+  ; published_at = {js|2021-08-27T11:20:09.000Z|js}
+  ; updated_at = {js|2021-09-06T12:02:00.082Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
  
   { name = {js|Core Time stamp counter: A fast high resolution time source|js}
-  ; embedPath = {js|/videos/embed/75b4d60f-3e37-40bd-b025-f39dcce0c42c|js}
-  ; thumbnailPath = {js|/static/thumbnails/43248673-6478-4e96-b8ac-cd415d85569b.jpg|js}
+  ; embed_path = {js|/videos/embed/75b4d60f-3e37-40bd-b025-f39dcce0c42c|js}
+  ; thumbnail_path = {js|/static/thumbnails/43248673-6478-4e96-b8ac-cd415d85569b.jpg|js}
   ; description = None
-  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; published_at = {js|2015-09-18T00:00:00.000Z|js}
+  ; updated_at = {js|2021-08-03T16:29:56.317Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
  
   { name = {js|Deductive Verification of Realistic OCaml Code|js}
-  ; embedPath = {js|/videos/embed/92309d92-8cbf-4545-980c-209c96e42a79|js}
-  ; thumbnailPath = {js|/static/thumbnails/db29d3bf-784c-47f1-bf90-f13fd2a9d530.jpg|js}
+  ; embed_path = {js|/videos/embed/92309d92-8cbf-4545-980c-209c96e42a79|js}
+  ; thumbnail_path = {js|/static/thumbnails/db29d3bf-784c-47f1-bf90-f13fd2a9d530.jpg|js}
   ; description = Some {js|We present the formal verification of a subset of the Set module from the OCaml standard library. The proof is conducted using Cameleer, a new tool for the deductive verification of OCaml code. Cameleer takes as input an OCaml program, annotated u...|js}
-  ; date = {js|2021-08-27T10:33:38.000Z|js}
+  ; published_at = {js|2021-08-27T10:33:38.000Z|js}
+  ; updated_at = {js|2021-09-07T04:02:00.301Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
  
   { name = {js|Digodoc and Docs|js}
-  ; embedPath = {js|/videos/embed/db6ed2c4-e940-4d5f-82ee-d3d20eb4ceb7|js}
-  ; thumbnailPath = {js|/static/thumbnails/43a418d6-56ec-48f4-852b-0a18ec0789aa.jpg|js}
+  ; embed_path = {js|/videos/embed/db6ed2c4-e940-4d5f-82ee-d3d20eb4ceb7|js}
+  ; thumbnail_path = {js|/static/thumbnails/43a418d6-56ec-48f4-852b-0a18ec0789aa.jpg|js}
   ; description = Some {js|In this talk, we will introduce a new tool called digodoc, that builds a graph of an opam switch, associating files, libraries and opam packages into a cyclic graph of inclusions and dependencies. We will then explain how we used that tool to buil...|js}
-  ; date = {js|2021-08-27T12:09:56.000Z|js}
+  ; published_at = {js|2021-08-27T12:09:56.000Z|js}
+  ; updated_at = {js|2021-09-07T20:02:00.180Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
  
   { name = {js|Effective Concurrency through Algebraic Effects|js}
-  ; embedPath = {js|/videos/embed/e9f6c837-1435-4349-af0f-07d22d1c11ea|js}
-  ; thumbnailPath = {js|/static/thumbnails/1de58bd2-d2f9-428c-8b8c-97b48d6d2c7e.jpg|js}
+  ; embed_path = {js|/videos/embed/e9f6c837-1435-4349-af0f-07d22d1c11ea|js}
+  ; thumbnail_path = {js|/static/thumbnails/1de58bd2-d2f9-428c-8b8c-97b48d6d2c7e.jpg|js}
   ; description = None
-  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; published_at = {js|2015-09-18T00:00:00.000Z|js}
+  ; updated_at = {js|2021-09-07T10:02:00.076Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
  
   { name = {js|Experiences with Effects in OCaml|js}
-  ; embedPath = {js|/videos/embed/74ece0a8-380f-4e2a-bef5-c6bb9092be89|js}
-  ; thumbnailPath = {js|/static/thumbnails/d48bf7bb-8c46-4d49-a3a6-734bf339343b.jpg|js}
+  ; embed_path = {js|/videos/embed/74ece0a8-380f-4e2a-bef5-c6bb9092be89|js}
+  ; thumbnail_path = {js|/static/thumbnails/d48bf7bb-8c46-4d49-a3a6-734bf339343b.jpg|js}
   ; description = Some {js|The multicore branch of OCaml adds support for effect handlers. In this talk, we report our experiences with effects, both from converting existing code, and from writing new code. Converting the Angstrom parser from a callback style to effects gr...|js}
-  ; date = {js|2021-08-27T14:41:07.000Z|js}
+  ; published_at = {js|2021-08-27T14:41:07.000Z|js}
+  ; updated_at = {js|2021-09-08T05:02:00.187Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
  
   { name = {js|From 2n+1 to n|js}
-  ; embedPath = {js|/videos/embed/74b32dae-11c6-4713-be1b-946260196e50|js}
-  ; thumbnailPath = {js|/static/thumbnails/a2042ab9-9025-421a-9eae-176462ac594b.jpg|js}
+  ; embed_path = {js|/videos/embed/74b32dae-11c6-4713-be1b-946260196e50|js}
+  ; thumbnail_path = {js|/static/thumbnails/a2042ab9-9025-421a-9eae-176462ac594b.jpg|js}
   ; description = Some {js|
 OCaml relies on a type-agnostic object representation centred around values which unify odd integers and aligned pointers. The last bit of a value distinguishes the two variants: zero indicates a pointer on the OCaml heap, while one encodes a ta...|js}
-  ; date = {js|2021-08-31T08:30:23.211Z|js}
+  ; published_at = {js|2021-08-31T08:30:23.211Z|js}
+  ; updated_at = {js|2021-09-06T14:02:00.190Z|js}
   ; language = {js|English|js}
   ; category = {js|Misc|js}
   };
  
   { name = {js|Global Semantic Analysis on OCaml programs|js}
-  ; embedPath = {js|/videos/embed/51e4bdf0-50f7-4b13-8514-2d62b5341066|js}
-  ; thumbnailPath = {js|/static/thumbnails/8255d370-e621-44bc-b7c3-6dd39fab4d1d.jpg|js}
+  ; embed_path = {js|/videos/embed/51e4bdf0-50f7-4b13-8514-2d62b5341066|js}
+  ; thumbnail_path = {js|/static/thumbnails/8255d370-e621-44bc-b7c3-6dd39fab4d1d.jpg|js}
   ; description = None
-  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; published_at = {js|2015-09-18T00:00:00.000Z|js}
+  ; updated_at = {js|2021-08-03T16:55:20.938Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
  
   { name = {js|GopCaml: A Structural Editor for OCaml|js}
-  ; embedPath = {js|/videos/embed/e0a6e6f2-0d40-4dfc-9308-001c8e0f64d6|js}
-  ; thumbnailPath = {js|/static/thumbnails/729cda51-abb3-4c8d-9d0e-b922e81be518.jpg|js}
+  ; embed_path = {js|/videos/embed/e0a6e6f2-0d40-4dfc-9308-001c8e0f64d6|js}
+  ; thumbnail_path = {js|/static/thumbnails/729cda51-abb3-4c8d-9d0e-b922e81be518.jpg|js}
   ; description = Some {js|This talk presents GopCaml-mode, the first structural editing plugin for OCaml. We will give a tour of the main plugin features, discussing the plugin’s internal design and its integration with existing OCaml and GNU Emacs toolchains.
 
 Kiran Gop...|js}
-  ; date = {js|2021-08-27T10:12:58.000Z|js}
+  ; published_at = {js|2021-08-27T10:12:58.000Z|js}
+  ; updated_at = {js|2021-09-07T15:02:00.164Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
  
   { name = {js|Inline Assembly in OCaml|js}
-  ; embedPath = {js|/videos/embed/632f520f-8f83-4b6f-89f1-5cde088436c7|js}
-  ; thumbnailPath = {js|/static/thumbnails/5d2f65d1-6129-4206-832b-c3d4bab410df.jpg|js}
+  ; embed_path = {js|/videos/embed/632f520f-8f83-4b6f-89f1-5cde088436c7|js}
+  ; thumbnail_path = {js|/static/thumbnails/5d2f65d1-6129-4206-832b-c3d4bab410df.jpg|js}
   ; description = None
-  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; published_at = {js|2015-09-18T00:00:00.000Z|js}
+  ; updated_at = {js|2021-08-03T16:39:42.613Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
  
   { name = {js|Irmin v2|js}
-  ; embedPath = {js|/videos/embed/53e497b0-898f-4c85-8da9-39f65ef0e0b1|js}
-  ; thumbnailPath = {js|/static/thumbnails/138e7c05-185b-4e54-95d0-d15018905a39.jpg|js}
+  ; embed_path = {js|/videos/embed/53e497b0-898f-4c85-8da9-39f65ef0e0b1|js}
+  ; thumbnail_path = {js|/static/thumbnails/138e7c05-185b-4e54-95d0-d15018905a39.jpg|js}
   ; description = Some {js|Irmin is an OCaml library for building distributed databases with the same design principles as Git. Existing Git users will find many familiar features: branching/merging, immutable causal history for all changes, and the ability to restore to an...|js}
-  ; date = {js|2020-08-28T00:00:00.000Z|js}
+  ; published_at = {js|2020-08-28T00:00:00.000Z|js}
+  ; updated_at = {js|2021-09-07T15:02:00.070Z|js}
   ; language = {js|Unknown|js}
   ; category = {js|Misc|js}
   };
  
   { name = {js|Ketrew and Biokepi|js}
-  ; embedPath = {js|/videos/embed/f3dcee35-bc04-453a-ba35-7aec90599661|js}
-  ; thumbnailPath = {js|/static/thumbnails/0a36e8ce-c415-4191-ad5b-6ef2eb23db4e.jpg|js}
+  ; embed_path = {js|/videos/embed/f3dcee35-bc04-453a-ba35-7aec90599661|js}
+  ; thumbnail_path = {js|/static/thumbnails/0a36e8ce-c415-4191-ad5b-6ef2eb23db4e.jpg|js}
   ; description = None
-  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; published_at = {js|2015-09-18T00:00:00.000Z|js}
+  ; updated_at = {js|2021-08-03T22:36:42.344Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
  
   { name = {js|Leveraging Formal Specifications to Generate Fuzzing Suites|js}
-  ; embedPath = {js|/videos/embed/d9a36c9f-1611-42f9-8854-981b1e2d7d75|js}
-  ; thumbnailPath = {js|/static/thumbnails/e5d18bd4-b482-463c-80f8-35d9fbb46b23.jpg|js}
+  ; embed_path = {js|/videos/embed/d9a36c9f-1611-42f9-8854-981b1e2d7d75|js}
+  ; thumbnail_path = {js|/static/thumbnails/e5d18bd4-b482-463c-80f8-35d9fbb46b23.jpg|js}
   ; description = Some {js|When testing a library, developers typically first have to capture the semantics they want to check. They then write the code implementing these tests and find relevant test cases that expose possible misbehaviours.
 
 In this work, we present a t...|js}
-  ; date = {js|2021-08-27T10:40:06.000Z|js}
+  ; published_at = {js|2021-08-27T10:40:06.000Z|js}
+  ; updated_at = {js|2021-09-07T04:02:00.442Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
  
   { name = {js|LexiFi Runtime Types|js}
-  ; embedPath = {js|/videos/embed/cc7e3242-0bef-448a-aa13-8827bba933e3|js}
-  ; thumbnailPath = {js|/static/thumbnails/1d43d8b4-87d1-4398-b925-10a42460b8dc.jpg|js}
+  ; embed_path = {js|/videos/embed/cc7e3242-0bef-448a-aa13-8827bba933e3|js}
+  ; thumbnail_path = {js|/static/thumbnails/1d43d8b4-87d1-4398-b925-10a42460b8dc.jpg|js}
   ; description = Some {js|OCaml programmers make deliberate use of abstract data types for composing safe and reliable software systems. The OCaml compiler relies on the invariants imposed by the type system to produce efficient and compact runtime data representations. Be...|js}
-  ; date = {js|2020-08-28T00:00:00.000Z|js}
+  ; published_at = {js|2020-08-28T00:00:00.000Z|js}
+  ; updated_at = {js|2021-08-29T09:02:00.090Z|js}
   ; language = {js|Unknown|js}
   ; category = {js|Science & Technology|js}
   };
  
   { name = {js|Love: a readable language interpreted by a blockchain|js}
-  ; embedPath = {js|/videos/embed/d3b2b31e-1739-406e-8de7-d5f21bc01836|js}
-  ; thumbnailPath = {js|/static/thumbnails/93a6e9ac-2266-408a-81e7-1ebf239233f8.jpg|js}
+  ; embed_path = {js|/videos/embed/d3b2b31e-1739-406e-8de7-d5f21bc01836|js}
+  ; thumbnail_path = {js|/static/thumbnails/93a6e9ac-2266-408a-81e7-1ebf239233f8.jpg|js}
   ; description = Some {js|We present Love, a smart contract language embedded in the Dune Network blockchain. It benefits from an OCaml-like syntax and a system-F inspired type system. Love has been used for deploying complex services such as games, ERC20s, atomic swaps, e...|js}
-  ; date = {js|2021-08-27T15:10:17.000Z|js}
+  ; published_at = {js|2021-08-27T15:10:17.000Z|js}
+  ; updated_at = {js|2021-09-02T23:02:00.323Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
  
   { name = {js|OCaml Under The Hood: SmartPy|js}
-  ; embedPath = {js|/videos/embed/7446ad4d-4ae2-4e1a-bc38-af8f71e8ebd8|js}
-  ; thumbnailPath = {js|/static/thumbnails/e1ac5b07-3648-40c1-b62c-5e88471741dc.jpg|js}
+  ; embed_path = {js|/videos/embed/7446ad4d-4ae2-4e1a-bc38-af8f71e8ebd8|js}
+  ; thumbnail_path = {js|/static/thumbnails/e1ac5b07-3648-40c1-b62c-5e88471741dc.jpg|js}
   ; description = Some {js|SmartPy is a complete system to develop smart-contracts for the Tezos blockchain. It is an embedded EDSL in python to write contracts and their test scenarios. It includes an online IDE, a chain explorer, and a command-line interface. Python is us...|js}
-  ; date = {js|2020-08-28T00:00:00.000Z|js}
+  ; published_at = {js|2020-08-28T00:00:00.000Z|js}
+  ; updated_at = {js|2021-05-19T17:08:00.226Z|js}
   ; language = {js|Unknown|js}
   ; category = {js|Misc|js}
   };
  
   { name = {js|OCaml and Python: Getting the Best of Both Worlds|js}
-  ; embedPath = {js|/videos/embed/9eafdb1e-9be9-4a52-98b4-f4696eda4c18|js}
-  ; thumbnailPath = {js|/static/thumbnails/53db83d1-0763-4dfa-a087-cce3cad1b581.jpg|js}
+  ; embed_path = {js|/videos/embed/9eafdb1e-9be9-4a52-98b4-f4696eda4c18|js}
+  ; thumbnail_path = {js|/static/thumbnails/53db83d1-0763-4dfa-a087-cce3cad1b581.jpg|js}
   ; description = Some {js|In this talk we present how we expose a wide variety of OCaml libraries and services so that they can be accessed from Python. Our initial use case on the Python side consisted in Jupyter notebooks used to analyse various datasets, these datasets ...|js}
-  ; date = {js|2021-08-27T10:16:54.000Z|js}
+  ; published_at = {js|2021-08-27T10:16:54.000Z|js}
+  ; updated_at = {js|2021-09-07T15:02:00.247Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
  
   { name = {js|OCaml-CI : A Zero-Configuration CI|js}
-  ; embedPath = {js|/videos/embed/0fee79e8-715a-400b-bfcc-34c3610f4890|js}
-  ; thumbnailPath = {js|/static/thumbnails/596f39a9-8654-4922-8bec-6e7ac5dcc319.jpg|js}
+  ; embed_path = {js|/videos/embed/0fee79e8-715a-400b-bfcc-34c3610f4890|js}
+  ; thumbnail_path = {js|/static/thumbnails/596f39a9-8654-4922-8bec-6e7ac5dcc319.jpg|js}
   ; description = Some {js|OCaml-CI
 
 is a CI service for OCaml projects. It
@@ -263,209 +290,231 @@ uses metadata from the project’s opam and dune
 files to work out what to build, and uses caching
 to make builds fast. It automatically tests projects
 against multiple OCaml versions and OS platforms...|js}
-  ; date = {js|2020-08-28T00:00:00.000Z|js}
+  ; published_at = {js|2020-08-28T00:00:00.000Z|js}
+  ; updated_at = {js|2021-09-04T20:02:00.100Z|js}
   ; language = {js|English|js}
   ; category = {js|Misc|js}
   };
  
   { name = {js|OCaml-CI : A Zero-Configuration CI|js}
-  ; embedPath = {js|/videos/embed/da88d6ac-7ba1-4261-9308-d03fe21e35b9|js}
-  ; thumbnailPath = {js|/static/thumbnails/1c22a14e-f067-4d4e-8e26-027cc6d8a491.jpg|js}
+  ; embed_path = {js|/videos/embed/da88d6ac-7ba1-4261-9308-d03fe21e35b9|js}
+  ; thumbnail_path = {js|/static/thumbnails/1c22a14e-f067-4d4e-8e26-027cc6d8a491.jpg|js}
   ; description = Some {js|OCaml-CI1 is a CI service for OCaml projects. It uses metadata from the project’s opam and dune files to work out what to build, and uses caching to make builds fast. It automatically tests projects against multiple OCaml versions and OS platforms...|js}
-  ; date = {js|2020-08-28T00:00:00.000Z|js}
+  ; published_at = {js|2020-08-28T00:00:00.000Z|js}
+  ; updated_at = {js|2021-05-27T16:35:41.085Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
  
   { name = {js|Opam-bin: Binary Packages with Opam|js}
-  ; embedPath = {js|/videos/embed/a889e4d3-0508-4734-b667-7060b0a253cd|js}
-  ; thumbnailPath = {js|/static/thumbnails/b2325a24-f068-473b-961e-a0b783ae5c39.jpg|js}
+  ; embed_path = {js|/videos/embed/a889e4d3-0508-4734-b667-7060b0a253cd|js}
+  ; thumbnail_path = {js|/static/thumbnails/b2325a24-f068-473b-961e-a0b783ae5c39.jpg|js}
   ; description = Some {js|In this talk, we will present opam-bin, an Opam plugin that builds Binary Opam packages on the fly, to speed-up reinstallation of pack- ages. opam-bin also creates Opam Repositories for these binary pack- ages, to make them easy to share with othe...|js}
-  ; date = {js|2021-08-27T15:01:40.000Z|js}
+  ; published_at = {js|2021-08-27T15:01:40.000Z|js}
+  ; updated_at = {js|2021-09-08T06:02:00.094Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
  
   { name = {js|Operf: Benchmarking the OCaml Compiler|js}
-  ; embedPath = {js|/videos/embed/5a4a6c12-3cb1-40d2-a663-25f294e12555|js}
-  ; thumbnailPath = {js|/static/thumbnails/c2b5c90a-9c9e-4058-94a1-15525795a01a.jpg|js}
+  ; embed_path = {js|/videos/embed/5a4a6c12-3cb1-40d2-a663-25f294e12555|js}
+  ; thumbnail_path = {js|/static/thumbnails/c2b5c90a-9c9e-4058-94a1-15525795a01a.jpg|js}
   ; description = None
-  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; published_at = {js|2015-09-18T00:00:00.000Z|js}
+  ; updated_at = {js|2021-08-03T16:23:23.889Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
  
   { name = {js|Parafuzz: Coverage-guided Property Fuzzing for Multicore OCaml programs|js}
-  ; embedPath = {js|/videos/embed/c0d591e0-91c9-4eaa-a4d7-c4f514de0a57|js}
-  ; thumbnailPath = {js|/static/thumbnails/b1a67c0a-2eb9-4c9d-97ce-b4dc039da59b.jpg|js}
+  ; embed_path = {js|/videos/embed/c0d591e0-91c9-4eaa-a4d7-c4f514de0a57|js}
+  ; thumbnail_path = {js|/static/thumbnails/b1a67c0a-2eb9-4c9d-97ce-b4dc039da59b.jpg|js}
   ; description = Some {js|We develop ParaFuzz, an input and concurrency fuzzing tool for Multicore OCaml programs. ParaFuzz builds on top of Crowbar which combines AFL-based grey box fuzzing with QuickCheck and extends it to handle parallelism.
 
 Sumit Padhiyar
 Indian In...|js}
-  ; date = {js|2021-08-27T10:36:13.000Z|js}
+  ; published_at = {js|2021-08-27T10:36:13.000Z|js}
+  ; updated_at = {js|2021-09-07T04:02:00.349Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
  
   { name = {js|Parallelising your OCaml Code with Multicore OCaml|js}
-  ; embedPath = {js|/videos/embed/ce20839e-4bfc-4d74-925b-485a6b052ddf|js}
-  ; thumbnailPath = {js|/static/thumbnails/30bc6019-ecab-40e5-a7b6-c294ac9a7344.jpg|js}
+  ; embed_path = {js|/videos/embed/ce20839e-4bfc-4d74-925b-485a6b052ddf|js}
+  ; thumbnail_path = {js|/static/thumbnails/30bc6019-ecab-40e5-a7b6-c294ac9a7344.jpg|js}
   ; description = Some {js|Slides, speaker notes and runnable examples mentioned in this talk are available at: https://github.com/ocaml-multicore/ocaml2020-workshop-parallel
 
 With the availability of multicore variants of the recent OCaml versions (4.10 and 4.11) that main...|js}
-  ; date = {js|2020-08-28T00:00:00.000Z|js}
+  ; published_at = {js|2020-08-28T00:00:00.000Z|js}
+  ; updated_at = {js|2021-09-05T03:02:00.936Z|js}
   ; language = {js|Unknown|js}
   ; category = {js|Misc|js}
   };
  
   { name = {js|Persistent Networking with Irmin and MirageOS|js}
-  ; embedPath = {js|/videos/embed/97dd9634-28e4-4066-96e4-9c2036ee4bb2|js}
-  ; thumbnailPath = {js|/static/thumbnails/46ba8c5d-0f4a-427e-8e76-0c58cb0e70a7.jpg|js}
+  ; embed_path = {js|/videos/embed/97dd9634-28e4-4066-96e4-9c2036ee4bb2|js}
+  ; thumbnail_path = {js|/static/thumbnails/46ba8c5d-0f4a-427e-8e76-0c58cb0e70a7.jpg|js}
   ; description = None
-  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; published_at = {js|2015-09-18T00:00:00.000Z|js}
+  ; updated_at = {js|2021-08-03T17:09:03.939Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
  
   { name = {js|Probabilistic resource limits using StatMemprof|js}
-  ; embedPath = {js|/videos/embed/bc297e85-82dd-4baf-8556-4a3a934978f9|js}
-  ; thumbnailPath = {js|/static/thumbnails/9b4dc06e-1d07-45b8-a21a-1e4f39897fef.jpg|js}
+  ; embed_path = {js|/videos/embed/bc297e85-82dd-4baf-8556-4a3a934978f9|js}
+  ; thumbnail_path = {js|/static/thumbnails/9b4dc06e-1d07-45b8-a21a-1e4f39897fef.jpg|js}
   ; description = Some {js|The goal of this talk is two-fold. First, we present memprof-limits, a probabilistic implementation of per-thread global memory limits, and per-thread allocation limits, for OCaml 4.12. Then, we will discuss the reasoning about programs in the pre...|js}
-  ; date = {js|2021-08-27T11:08:12.000Z|js}
+  ; published_at = {js|2021-08-27T11:08:12.000Z|js}
+  ; updated_at = {js|2021-09-06T04:02:01.770Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
  
   { name = {js|Property-Based Testing for OCaml through Coq|js}
-  ; embedPath = {js|/videos/embed/9324fba4-2482-4bab-bfdd-b8881b3ed94a|js}
-  ; thumbnailPath = {js|/static/thumbnails/d7e22bba-cda1-4c2b-9368-9b2c1643e751.jpg|js}
+  ; embed_path = {js|/videos/embed/9324fba4-2482-4bab-bfdd-b8881b3ed94a|js}
+  ; thumbnail_path = {js|/static/thumbnails/d7e22bba-cda1-4c2b-9368-9b2c1643e751.jpg|js}
   ; description = Some {js|We will present a property-based testing framework for OCaml that leverages the power of QuickChick, a popular and mature testing plugin for the Coq proof assistant, by automatically constructing a extraction-based shim between OCaml and Coq. That...|js}
-  ; date = {js|2021-08-31T08:37:00.571Z|js}
+  ; published_at = {js|2021-08-31T08:37:00.571Z|js}
+  ; updated_at = {js|2021-09-06T10:02:00.283Z|js}
   ; language = {js|English|js}
   ; category = {js|Misc|js}
   };
  
   { name = {js|Safe Protocol Updates via Propositional Logic|js}
-  ; embedPath = {js|/videos/embed/c6176f51-0277-46f0-937b-1e2721044492|js}
-  ; thumbnailPath = {js|/static/thumbnails/a89a3483-274a-44f1-9a38-c679f6b12196.jpg|js}
+  ; embed_path = {js|/videos/embed/c6176f51-0277-46f0-937b-1e2721044492|js}
+  ; thumbnail_path = {js|/static/thumbnails/a89a3483-274a-44f1-9a38-c679f6b12196.jpg|js}
   ; description = Some {js|If values of a given type are stored on disk, or are sent between different executables, then changing that type or its serialization can result in versioning issues.
 Often such issues are resolved by either making the deserializer more permissiv...|js}
-  ; date = {js|2021-08-31T08:34:54.707Z|js}
+  ; published_at = {js|2021-08-31T08:34:54.707Z|js}
+  ; updated_at = {js|2021-09-04T14:02:00.088Z|js}
   ; language = {js|English|js}
   ; category = {js|Misc|js}
   };
  
   { name = {js|Semgrep : a fast, lightweight, polyglot static analysis tool to find bugs|js}
-  ; embedPath = {js|/videos/embed/c0d07213-1426-46a1-98e0-0b0c4515c841|js}
-  ; thumbnailPath = {js|/static/thumbnails/2ab3961f-4e66-4ec9-b20e-72e25dfbebe4.jpg|js}
+  ; embed_path = {js|/videos/embed/c0d07213-1426-46a1-98e0-0b0c4515c841|js}
+  ; thumbnail_path = {js|/static/thumbnails/2ab3961f-4e66-4ec9-b20e-72e25dfbebe4.jpg|js}
   ; description = Some {js|Semgrep, which stands for “semantic grep,” is a fast, lightweight, polyglot, open source static analysis tool to find bugs and enforce code standards. It is used internally by many companies including Dropbox and Snowflake. Semgrep is also now use...|js}
-  ; date = {js|2021-08-31T08:41:15.492Z|js}
+  ; published_at = {js|2021-08-31T08:41:15.492Z|js}
+  ; updated_at = {js|2021-09-05T16:02:01.373Z|js}
   ; language = {js|English|js}
   ; category = {js|Misc|js}
   };
  
   { name = {js|Specialization of Generic Array Accesses After Inlining|js}
-  ; embedPath = {js|/videos/embed/80553916-b90a-4641-93c8-35b000df04c1|js}
-  ; thumbnailPath = {js|/static/thumbnails/1f81fbbf-6fb0-4047-93a1-57759431166a.jpg|js}
+  ; embed_path = {js|/videos/embed/80553916-b90a-4641-93c8-35b000df04c1|js}
+  ; thumbnail_path = {js|/static/thumbnails/1f81fbbf-6fb0-4047-93a1-57759431166a.jpg|js}
   ; description = None
-  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; published_at = {js|2015-09-18T00:00:00.000Z|js}
+  ; updated_at = {js|2021-08-03T16:34:23.463Z|js}
   ; language = {js|Unknown|js}
   ; category = {js|Science & Technology|js}
   };
  
   { name = {js|State of the OCaml Platform|js}
-  ; embedPath = {js|/videos/embed/390ce74c-f85f-477d-8f20-504437409add|js}
-  ; thumbnailPath = {js|/static/thumbnails/33258292-009b-42ee-83d3-9eb4bfb4e048.jpg|js}
+  ; embed_path = {js|/videos/embed/390ce74c-f85f-477d-8f20-504437409add|js}
+  ; thumbnail_path = {js|/static/thumbnails/33258292-009b-42ee-83d3-9eb4bfb4e048.jpg|js}
   ; description = None
-  ; date = {js|2018-01-12T00:00:00.000Z|js}
+  ; published_at = {js|2018-01-12T00:00:00.000Z|js}
+  ; updated_at = {js|2021-07-27T12:08:00.264Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
  
   { name = {js|State of the OCaml Platform 2020|js}
-  ; embedPath = {js|/videos/embed/0e2070fd-798b-47f7-8e69-ef75e967e516|js}
-  ; thumbnailPath = {js|/static/thumbnails/4fd6a51f-686c-4f6f-8026-83692304b432.jpg|js}
+  ; embed_path = {js|/videos/embed/0e2070fd-798b-47f7-8e69-ef75e967e516|js}
+  ; thumbnail_path = {js|/static/thumbnails/4fd6a51f-686c-4f6f-8026-83692304b432.jpg|js}
   ; description = Some {js|This talk covers:
 
 - Integrated Development Environments
 - Next Steps for the OCaml Platform
 - Plans for 2020-2021|js}
-  ; date = {js|2020-08-28T00:00:00.000Z|js}
+  ; published_at = {js|2020-08-28T00:00:00.000Z|js}
+  ; updated_at = {js|2021-08-30T08:02:00.086Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
  
   { name = {js|The ImpFS filesystem|js}
-  ; embedPath = {js|/videos/embed/28545b27-4637-47a5-8edd-6b904daef19c|js}
-  ; thumbnailPath = {js|/static/thumbnails/dde19660-653d-4dc3-9e81-54b2e3ab22a2.jpg|js}
+  ; embed_path = {js|/videos/embed/28545b27-4637-47a5-8edd-6b904daef19c|js}
+  ; thumbnail_path = {js|/static/thumbnails/dde19660-653d-4dc3-9e81-54b2e3ab22a2.jpg|js}
   ; description = Some {js|This proposal describes a presentation to be given at the OCaml’20 workshop. The presentation will cover a new OCaml filesystem, ImpFS, and the related libraries. The filesystem makes use of a B-tree library presented at OCaml’17, and a key-value ...|js}
-  ; date = {js|2020-08-28T00:00:00.000Z|js}
+  ; published_at = {js|2020-08-28T00:00:00.000Z|js}
+  ; updated_at = {js|2021-09-04T20:02:00.472Z|js}
   ; language = {js|Unknown|js}
   ; category = {js|Misc|js}
   };
  
   { name = {js|The OCaml Platform 1.0 - Reason ML|js}
-  ; embedPath = {js|/videos/embed/bd9a8e54-6ca5-4036-a08c-6a47cee6619e|js}
-  ; thumbnailPath = {js|/static/thumbnails/ddc1e6fb-9999-4e79-b458-31c7e3ec1108.jpg|js}
+  ; embed_path = {js|/videos/embed/bd9a8e54-6ca5-4036-a08c-6a47cee6619e|js}
+  ; thumbnail_path = {js|/static/thumbnails/ddc1e6fb-9999-4e79-b458-31c7e3ec1108.jpg|js}
   ; description = Some {js|Presented by Anil Madhavapeddy (@avsm)
 
 We keep being told ReasonML can compile to native and do interop with OCaml, and that there's a wealth of existing code and tools we can draw into our applications - but how do we get there?
 This video will ...|js}
-  ; date = {js|2018-12-11T00:00:00.000Z|js}
+  ; published_at = {js|2018-12-11T00:00:00.000Z|js}
+  ; updated_at = {js|2021-09-03T14:02:00.094Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
  
   { name = {js|The State of OCaml|js}
-  ; embedPath = {js|/videos/embed/60a2ecfb-86ea-4881-a279-0a928452a3c3|js}
-  ; thumbnailPath = {js|/static/thumbnails/a5e5f630-2df9-4691-8ddf-a8137001ab4c.jpg|js}
+  ; embed_path = {js|/videos/embed/60a2ecfb-86ea-4881-a279-0a928452a3c3|js}
+  ; thumbnail_path = {js|/static/thumbnails/a5e5f630-2df9-4691-8ddf-a8137001ab4c.jpg|js}
   ; description = None
-  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; published_at = {js|2015-09-18T00:00:00.000Z|js}
+  ; updated_at = {js|2021-09-02T10:02:00.083Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
  
   { name = {js|The State of the OCaml Platform|js}
-  ; embedPath = {js|/videos/embed/32475a83-b455-455b-937f-28e7185f4fc2|js}
-  ; thumbnailPath = {js|/static/thumbnails/7eb8af05-a6d5-4a88-89f3-146673a87cf0.jpg|js}
+  ; embed_path = {js|/videos/embed/32475a83-b455-455b-937f-28e7185f4fc2|js}
+  ; thumbnail_path = {js|/static/thumbnails/7eb8af05-a6d5-4a88-89f3-146673a87cf0.jpg|js}
   ; description = None
-  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; published_at = {js|2015-09-18T00:00:00.000Z|js}
+  ; updated_at = {js|2021-08-03T16:47:54.414Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
  
   { name = {js|The final pieces of the OCaml documentation puzzle|js}
-  ; embedPath = {js|/videos/embed/2acebff9-25fa-4733-83cc-620a65b12251|js}
-  ; thumbnailPath = {js|/static/thumbnails/c877a501-c705-44f7-8826-e7ce846a5e42.jpg|js}
+  ; embed_path = {js|/videos/embed/2acebff9-25fa-4733-83cc-620a65b12251|js}
+  ; thumbnail_path = {js|/static/thumbnails/c877a501-c705-44f7-8826-e7ce846a5e42.jpg|js}
   ; description = Some {js|Rendering OCaml document is widely known as a very difficult task: The ever-evolving OCaml module system is extremely rich and can include complex set of inter-dependencies that are both difficult to compute and to render in a concise document. It...|js}
-  ; date = {js|2020-08-28T00:00:00.000Z|js}
+  ; published_at = {js|2020-08-28T00:00:00.000Z|js}
+  ; updated_at = {js|2021-09-05T03:02:00.455Z|js}
   ; language = {js|English|js}
   ; category = {js|Misc|js}
   };
  
   { name = {js|Towards A Debugger for Native Code OCaml|js}
-  ; embedPath = {js|/videos/embed/b76f3301-261d-44f3-97ec-1910b45f6969|js}
-  ; thumbnailPath = {js|/static/thumbnails/93ea327e-5e8b-4844-b237-75719a7256b9.jpg|js}
+  ; embed_path = {js|/videos/embed/b76f3301-261d-44f3-97ec-1910b45f6969|js}
+  ; thumbnail_path = {js|/static/thumbnails/93ea327e-5e8b-4844-b237-75719a7256b9.jpg|js}
   ; description = None
-  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; published_at = {js|2015-09-18T00:00:00.000Z|js}
+  ; updated_at = {js|2021-08-03T16:20:17.728Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
  
   { name = {js|Types in Amber|js}
-  ; embedPath = {js|/videos/embed/99b3dc75-9f93-4677-9f8b-076546725512|js}
-  ; thumbnailPath = {js|/static/thumbnails/acd50ed1-43cf-45fd-a55e-9c40a6bf58ba.jpg|js}
+  ; embed_path = {js|/videos/embed/99b3dc75-9f93-4677-9f8b-076546725512|js}
+  ; thumbnail_path = {js|/static/thumbnails/acd50ed1-43cf-45fd-a55e-9c40a6bf58ba.jpg|js}
   ; description = Some {js|Coda is a new cryptocurrency that uses zk-SNARKs to dramatically reduce the size of data needed by nodes running its protocol. Nodes communicate in a format automatically derived from type definitions in OCaml source files. As the Coda software ev...|js}
-  ; date = {js|2020-08-28T00:00:00.000Z|js}
+  ; published_at = {js|2020-08-28T00:00:00.000Z|js}
+  ; updated_at = {js|2021-08-29T09:02:00.201Z|js}
   ; language = {js|Unknown|js}
   ; category = {js|Misc|js}
   };
  
   { name = {js|Wibbily Wobbly Timey Camly|js}
-  ; embedPath = {js|/videos/embed/ec641446-823b-40ec-a207-85157a18f88e|js}
-  ; thumbnailPath = {js|/static/thumbnails/2300474a-7615-4c92-9489-9ff5117d8bc7.jpg|js}
+  ; embed_path = {js|/videos/embed/ec641446-823b-40ec-a207-85157a18f88e|js}
+  ; thumbnail_path = {js|/static/thumbnails/2300474a-7615-4c92-9489-9ff5117d8bc7.jpg|js}
   ; description = Some {js|Time handling is commonly considered a difficult problem by programmers due to myriad standards and complexity of time zone definitions. This also complicates scheduling across multiple time zones especially when one takes Daylight Saving Time int...|js}
-  ; date = {js|2021-08-27T10:37:18.000Z|js}
+  ; published_at = {js|2021-08-27T10:37:18.000Z|js}
+  ; updated_at = {js|2021-09-07T04:02:00.396Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   }]

--- a/src/ood/watch.ml
+++ b/src/ood/watch.ml
@@ -12,13 +12,76 @@
   
 let all = 
 [
-  { name = {js|Semgrep : a fast, lightweight, polyglot static analysis tool to find bugs|js}
-  ; embedPath = {js|/videos/embed/c0d07213-1426-46a1-98e0-0b0c4515c841|js}
-  ; thumbnailPath = {js|/static/thumbnails/2ab3961f-4e66-4ec9-b20e-72e25dfbebe4.jpg|js}
-  ; description = Some {js|Semgrep, which stands for “semantic grep,” is a fast, lightweight, polyglot, open source static analysis tool to find bugs and enforce code standards. It is used internally by many companies including Dropbox and Snowflake. Semgrep is also now use...|js}
-  ; date = {js|2021-08-31T08:41:15.492Z|js}
+  { name = {js|25 Years of OCaml: Xavier Leroy|js}
+  ; embedPath = {js|/videos/embed/e1ee0fc0-50ef-4a1c-894a-17df181424cb|js}
+  ; thumbnailPath = {js|/static/thumbnails/94ead657-79a0-4c10-8435-9e13906a6c44.jpg|js}
+  ; description = Some {js|Professor Xavier Leroy -- the primary original author and leader of the OCaml project -- reflects on 25 years of the OCaml language at his OCaml Workshop 2021 keynote speech.|js}
+  ; date = {js|2021-08-27T13:23:10.199Z|js}
   ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|A Declarative Syntax Definition for OCaml|js}
+  ; embedPath = {js|/videos/embed/a5b86864-8e43-4138-b6d6-ed48d2d4b63d|js}
+  ; thumbnailPath = {js|/static/thumbnails/92c0a0e3-5326-42aa-86a3-6adb3927e111.jpg|js}
+  ; description = Some {js|In this talk, we present our work on a syntax definition for the OCaml language in the syntax definition formalism SDF3. SDF3 supports the high-level definition of concrete and abstract syntax through declarative disambiguation and definition of c...|js}
+  ; date = {js|2020-08-28T00:00:00.000Z|js}
+  ; language = {js|Unknown|js}
   ; category = {js|Misc|js}
+  };
+ 
+  { name = {js|A Multiverse of Glorious Documentation|js}
+  ; embedPath = {js|/videos/embed/9bb452d6-1829-4dac-a6a2-46b31050c931|js}
+  ; thumbnailPath = {js|/static/thumbnails/6a0a8291-4626-4820-8071-904b3c508345.jpg|js}
+  ; description = Some {js|This talk describes the process of generating documentation for every version of every package that can be built from the opam repository, and how it is presented as a single coherent website that is continuously updated as new packages are releas...|js}
+  ; date = {js|2021-08-27T11:23:36.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|A Simple State-Machine Framework for Property-Based Testing in OCaml|js}
+  ; embedPath = {js|/videos/embed/08b429ea-2eb8-427d-a625-5495f4ee0fef|js}
+  ; thumbnailPath = {js|/static/thumbnails/316ddad9-dbc3-4d46-9f43-5da72689e93b.jpg|js}
+  ; description = Some {js|Since their inception, state-machine frameworks have proven their worth by finding defects in everything from the underlying AUTOSAR components of Volvo cars to digital invoicing systems. These case studies were carried out with Erlang’s commercia...|js}
+  ; date = {js|2020-08-28T00:00:00.000Z|js}
+  ; language = {js|Unknown|js}
+  ; category = {js|Misc|js}
+  };
+ 
+  { name = {js|A review of the growth of the OCaml community|js}
+  ; embedPath = {js|/videos/embed/f9d0b637-8aec-4bff-8c32-cd16b58023b6|js}
+  ; thumbnailPath = {js|/static/thumbnails/e573402b-1350-4aa7-a9ba-0e1c51198fb4.jpg|js}
+  ; description = None
+  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; language = {js|Unknown|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|AD-OCaml: Algorithmic Differentiation for OCaml|js}
+  ; embedPath = {js|/videos/embed/c9e85690-732f-4b03-836f-2ee0fd8f0658|js}
+  ; thumbnailPath = {js|/static/thumbnails/eb972fd2-668e-4998-a798-e9fbdcadba20.jpg|js}
+  ; description = Some {js|AD-OCaml is a library framework for calculating mathematically exact derivatives and deep power series approximations of almost arbitrary OCaml programs via algorithmic differentiation. Unlike similar frameworks, this includes programs with side e...|js}
+  ; date = {js|2020-08-28T00:00:00.000Z|js}
+  ; language = {js|Unknown|js}
+  ; category = {js|Misc|js}
+  };
+ 
+  { name = {js|API migration: compare transformed|js}
+  ; embedPath = {js|/videos/embed/c46b925b-bd77-404f-ac5d-5dab65047529|js}
+  ; thumbnailPath = {js|/static/thumbnails/eef64419-3c34-4c15-9419-edcbc455e54d.jpg|js}
+  ; description = Some {js|In this talk we describe our experience in using an automatic API-migration strategy dedicated at changing the signatures of OCaml functions, using the Rotor refactoring tool for OCaml. We perform a case study on open source Jane Street libraries ...|js}
+  ; date = {js|2020-08-28T00:00:00.000Z|js}
+  ; language = {js|Unknown|js}
+  ; category = {js|Misc|js}
+  };
+ 
+  { name = {js|Adapting the OCaml ecosystem for Multicore OCaml|js}
+  ; embedPath = {js|/videos/embed/629b89a8-bbd5-490d-98b0-d0c740912b02|js}
+  ; thumbnailPath = {js|/static/thumbnails/41212c84-36d6-44fa-b884-2ced79505929.jpg|js}
+  ; description = Some {js|OCaml 5.0 with support for shared-memory parallelism being around the corner, there’s increasing interest in the community to port existing libraries to Multicore. This talk will take the attendees through what the arrival of Multicore means to th...|js}
+  ; date = {js|2021-08-27T10:18:38.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
   };
  
   { name = {js|Binary Analysis Platform|js}
@@ -28,6 +91,249 @@ let all =
   ; date = {js|2021-08-31T08:39:55.774Z|js}
   ; language = {js|English|js}
   ; category = {js|Misc|js}
+  };
+ 
+  { name = {js|Continuous Benchmarking for OCaml Projects|js}
+  ; embedPath = {js|/videos/embed/1c994370-1aaa-4db6-b901-d762786e4904|js}
+  ; thumbnailPath = {js|/static/thumbnails/33ab36c3-3650-4c13-9fea-9b5907cf8c0f.jpg|js}
+  ; description = Some {js|Regular CI systems are optimised for workloads that do not require stable performance over time. This makes them unsuitable for running performance benchmarks.
+
+current-bench provides a predictable environment for performance benchmarks and a UI...|js}
+  ; date = {js|2021-08-27T11:20:09.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Core Time stamp counter: A fast high resolution time source|js}
+  ; embedPath = {js|/videos/embed/75b4d60f-3e37-40bd-b025-f39dcce0c42c|js}
+  ; thumbnailPath = {js|/static/thumbnails/43248673-6478-4e96-b8ac-cd415d85569b.jpg|js}
+  ; description = None
+  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Deductive Verification of Realistic OCaml Code|js}
+  ; embedPath = {js|/videos/embed/92309d92-8cbf-4545-980c-209c96e42a79|js}
+  ; thumbnailPath = {js|/static/thumbnails/db29d3bf-784c-47f1-bf90-f13fd2a9d530.jpg|js}
+  ; description = Some {js|We present the formal verification of a subset of the Set module from the OCaml standard library. The proof is conducted using Cameleer, a new tool for the deductive verification of OCaml code. Cameleer takes as input an OCaml program, annotated u...|js}
+  ; date = {js|2021-08-27T10:33:38.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Digodoc and Docs|js}
+  ; embedPath = {js|/videos/embed/db6ed2c4-e940-4d5f-82ee-d3d20eb4ceb7|js}
+  ; thumbnailPath = {js|/static/thumbnails/43a418d6-56ec-48f4-852b-0a18ec0789aa.jpg|js}
+  ; description = Some {js|In this talk, we will introduce a new tool called digodoc, that builds a graph of an opam switch, associating files, libraries and opam packages into a cyclic graph of inclusions and dependencies. We will then explain how we used that tool to buil...|js}
+  ; date = {js|2021-08-27T12:09:56.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Effective Concurrency through Algebraic Effects|js}
+  ; embedPath = {js|/videos/embed/e9f6c837-1435-4349-af0f-07d22d1c11ea|js}
+  ; thumbnailPath = {js|/static/thumbnails/1de58bd2-d2f9-428c-8b8c-97b48d6d2c7e.jpg|js}
+  ; description = None
+  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Experiences with Effects in OCaml|js}
+  ; embedPath = {js|/videos/embed/74ece0a8-380f-4e2a-bef5-c6bb9092be89|js}
+  ; thumbnailPath = {js|/static/thumbnails/d48bf7bb-8c46-4d49-a3a6-734bf339343b.jpg|js}
+  ; description = Some {js|The multicore branch of OCaml adds support for effect handlers. In this talk, we report our experiences with effects, both from converting existing code, and from writing new code. Converting the Angstrom parser from a callback style to effects gr...|js}
+  ; date = {js|2021-08-27T14:41:07.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|From 2n+1 to n|js}
+  ; embedPath = {js|/videos/embed/74b32dae-11c6-4713-be1b-946260196e50|js}
+  ; thumbnailPath = {js|/static/thumbnails/a2042ab9-9025-421a-9eae-176462ac594b.jpg|js}
+  ; description = Some {js|
+OCaml relies on a type-agnostic object representation centred around values which unify odd integers and aligned pointers. The last bit of a value distinguishes the two variants: zero indicates a pointer on the OCaml heap, while one encodes a ta...|js}
+  ; date = {js|2021-08-31T08:30:23.211Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Misc|js}
+  };
+ 
+  { name = {js|Global Semantic Analysis on OCaml programs|js}
+  ; embedPath = {js|/videos/embed/51e4bdf0-50f7-4b13-8514-2d62b5341066|js}
+  ; thumbnailPath = {js|/static/thumbnails/8255d370-e621-44bc-b7c3-6dd39fab4d1d.jpg|js}
+  ; description = None
+  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|GopCaml: A Structural Editor for OCaml|js}
+  ; embedPath = {js|/videos/embed/e0a6e6f2-0d40-4dfc-9308-001c8e0f64d6|js}
+  ; thumbnailPath = {js|/static/thumbnails/729cda51-abb3-4c8d-9d0e-b922e81be518.jpg|js}
+  ; description = Some {js|This talk presents GopCaml-mode, the first structural editing plugin for OCaml. We will give a tour of the main plugin features, discussing the plugin’s internal design and its integration with existing OCaml and GNU Emacs toolchains.
+
+Kiran Gop...|js}
+  ; date = {js|2021-08-27T10:12:58.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Inline Assembly in OCaml|js}
+  ; embedPath = {js|/videos/embed/632f520f-8f83-4b6f-89f1-5cde088436c7|js}
+  ; thumbnailPath = {js|/static/thumbnails/5d2f65d1-6129-4206-832b-c3d4bab410df.jpg|js}
+  ; description = None
+  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Irmin v2|js}
+  ; embedPath = {js|/videos/embed/53e497b0-898f-4c85-8da9-39f65ef0e0b1|js}
+  ; thumbnailPath = {js|/static/thumbnails/138e7c05-185b-4e54-95d0-d15018905a39.jpg|js}
+  ; description = Some {js|Irmin is an OCaml library for building distributed databases with the same design principles as Git. Existing Git users will find many familiar features: branching/merging, immutable causal history for all changes, and the ability to restore to an...|js}
+  ; date = {js|2020-08-28T00:00:00.000Z|js}
+  ; language = {js|Unknown|js}
+  ; category = {js|Misc|js}
+  };
+ 
+  { name = {js|Ketrew and Biokepi|js}
+  ; embedPath = {js|/videos/embed/f3dcee35-bc04-453a-ba35-7aec90599661|js}
+  ; thumbnailPath = {js|/static/thumbnails/0a36e8ce-c415-4191-ad5b-6ef2eb23db4e.jpg|js}
+  ; description = None
+  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Leveraging Formal Specifications to Generate Fuzzing Suites|js}
+  ; embedPath = {js|/videos/embed/d9a36c9f-1611-42f9-8854-981b1e2d7d75|js}
+  ; thumbnailPath = {js|/static/thumbnails/e5d18bd4-b482-463c-80f8-35d9fbb46b23.jpg|js}
+  ; description = Some {js|When testing a library, developers typically first have to capture the semantics they want to check. They then write the code implementing these tests and find relevant test cases that expose possible misbehaviours.
+
+In this work, we present a t...|js}
+  ; date = {js|2021-08-27T10:40:06.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|LexiFi Runtime Types|js}
+  ; embedPath = {js|/videos/embed/cc7e3242-0bef-448a-aa13-8827bba933e3|js}
+  ; thumbnailPath = {js|/static/thumbnails/1d43d8b4-87d1-4398-b925-10a42460b8dc.jpg|js}
+  ; description = Some {js|OCaml programmers make deliberate use of abstract data types for composing safe and reliable software systems. The OCaml compiler relies on the invariants imposed by the type system to produce efficient and compact runtime data representations. Be...|js}
+  ; date = {js|2020-08-28T00:00:00.000Z|js}
+  ; language = {js|Unknown|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Love: a readable language interpreted by a blockchain|js}
+  ; embedPath = {js|/videos/embed/d3b2b31e-1739-406e-8de7-d5f21bc01836|js}
+  ; thumbnailPath = {js|/static/thumbnails/93a6e9ac-2266-408a-81e7-1ebf239233f8.jpg|js}
+  ; description = Some {js|We present Love, a smart contract language embedded in the Dune Network blockchain. It benefits from an OCaml-like syntax and a system-F inspired type system. Love has been used for deploying complex services such as games, ERC20s, atomic swaps, e...|js}
+  ; date = {js|2021-08-27T15:10:17.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|OCaml Under The Hood: SmartPy|js}
+  ; embedPath = {js|/videos/embed/7446ad4d-4ae2-4e1a-bc38-af8f71e8ebd8|js}
+  ; thumbnailPath = {js|/static/thumbnails/e1ac5b07-3648-40c1-b62c-5e88471741dc.jpg|js}
+  ; description = Some {js|SmartPy is a complete system to develop smart-contracts for the Tezos blockchain. It is an embedded EDSL in python to write contracts and their test scenarios. It includes an online IDE, a chain explorer, and a command-line interface. Python is us...|js}
+  ; date = {js|2020-08-28T00:00:00.000Z|js}
+  ; language = {js|Unknown|js}
+  ; category = {js|Misc|js}
+  };
+ 
+  { name = {js|OCaml and Python: Getting the Best of Both Worlds|js}
+  ; embedPath = {js|/videos/embed/9eafdb1e-9be9-4a52-98b4-f4696eda4c18|js}
+  ; thumbnailPath = {js|/static/thumbnails/53db83d1-0763-4dfa-a087-cce3cad1b581.jpg|js}
+  ; description = Some {js|In this talk we present how we expose a wide variety of OCaml libraries and services so that they can be accessed from Python. Our initial use case on the Python side consisted in Jupyter notebooks used to analyse various datasets, these datasets ...|js}
+  ; date = {js|2021-08-27T10:16:54.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|OCaml-CI : A Zero-Configuration CI|js}
+  ; embedPath = {js|/videos/embed/0fee79e8-715a-400b-bfcc-34c3610f4890|js}
+  ; thumbnailPath = {js|/static/thumbnails/596f39a9-8654-4922-8bec-6e7ac5dcc319.jpg|js}
+  ; description = Some {js|OCaml-CI
+
+is a CI service for OCaml projects. It
+uses metadata from the project’s opam and dune
+files to work out what to build, and uses caching
+to make builds fast. It automatically tests projects
+against multiple OCaml versions and OS platforms...|js}
+  ; date = {js|2020-08-28T00:00:00.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Misc|js}
+  };
+ 
+  { name = {js|OCaml-CI : A Zero-Configuration CI|js}
+  ; embedPath = {js|/videos/embed/da88d6ac-7ba1-4261-9308-d03fe21e35b9|js}
+  ; thumbnailPath = {js|/static/thumbnails/1c22a14e-f067-4d4e-8e26-027cc6d8a491.jpg|js}
+  ; description = Some {js|OCaml-CI1 is a CI service for OCaml projects. It uses metadata from the project’s opam and dune files to work out what to build, and uses caching to make builds fast. It automatically tests projects against multiple OCaml versions and OS platforms...|js}
+  ; date = {js|2020-08-28T00:00:00.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Opam-bin: Binary Packages with Opam|js}
+  ; embedPath = {js|/videos/embed/a889e4d3-0508-4734-b667-7060b0a253cd|js}
+  ; thumbnailPath = {js|/static/thumbnails/b2325a24-f068-473b-961e-a0b783ae5c39.jpg|js}
+  ; description = Some {js|In this talk, we will present opam-bin, an Opam plugin that builds Binary Opam packages on the fly, to speed-up reinstallation of pack- ages. opam-bin also creates Opam Repositories for these binary pack- ages, to make them easy to share with othe...|js}
+  ; date = {js|2021-08-27T15:01:40.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Operf: Benchmarking the OCaml Compiler|js}
+  ; embedPath = {js|/videos/embed/5a4a6c12-3cb1-40d2-a663-25f294e12555|js}
+  ; thumbnailPath = {js|/static/thumbnails/c2b5c90a-9c9e-4058-94a1-15525795a01a.jpg|js}
+  ; description = None
+  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Parafuzz: Coverage-guided Property Fuzzing for Multicore OCaml programs|js}
+  ; embedPath = {js|/videos/embed/c0d591e0-91c9-4eaa-a4d7-c4f514de0a57|js}
+  ; thumbnailPath = {js|/static/thumbnails/b1a67c0a-2eb9-4c9d-97ce-b4dc039da59b.jpg|js}
+  ; description = Some {js|We develop ParaFuzz, an input and concurrency fuzzing tool for Multicore OCaml programs. ParaFuzz builds on top of Crowbar which combines AFL-based grey box fuzzing with QuickCheck and extends it to handle parallelism.
+
+Sumit Padhiyar
+Indian In...|js}
+  ; date = {js|2021-08-27T10:36:13.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Parallelising your OCaml Code with Multicore OCaml|js}
+  ; embedPath = {js|/videos/embed/ce20839e-4bfc-4d74-925b-485a6b052ddf|js}
+  ; thumbnailPath = {js|/static/thumbnails/30bc6019-ecab-40e5-a7b6-c294ac9a7344.jpg|js}
+  ; description = Some {js|Slides, speaker notes and runnable examples mentioned in this talk are available at: https://github.com/ocaml-multicore/ocaml2020-workshop-parallel
+
+With the availability of multicore variants of the recent OCaml versions (4.10 and 4.11) that main...|js}
+  ; date = {js|2020-08-28T00:00:00.000Z|js}
+  ; language = {js|Unknown|js}
+  ; category = {js|Misc|js}
+  };
+ 
+  { name = {js|Persistent Networking with Irmin and MirageOS|js}
+  ; embedPath = {js|/videos/embed/97dd9634-28e4-4066-96e4-9c2036ee4bb2|js}
+  ; thumbnailPath = {js|/static/thumbnails/46ba8c5d-0f4a-427e-8e76-0c58cb0e70a7.jpg|js}
+  ; description = None
+  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Probabilistic resource limits using StatMemprof|js}
+  ; embedPath = {js|/videos/embed/bc297e85-82dd-4baf-8556-4a3a934978f9|js}
+  ; thumbnailPath = {js|/static/thumbnails/9b4dc06e-1d07-45b8-a21a-1e4f39897fef.jpg|js}
+  ; description = Some {js|The goal of this talk is two-fold. First, we present memprof-limits, a probabilistic implementation of per-thread global memory limits, and per-thread allocation limits, for OCaml 4.12. Then, we will discuss the reasoning about programs in the pre...|js}
+  ; date = {js|2021-08-27T11:08:12.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
   };
  
   { name = {js|Property-Based Testing for OCaml through Coq|js}
@@ -49,156 +355,29 @@ Often such issues are resolved by either making the deserializer more permissiv.
   ; category = {js|Misc|js}
   };
  
-  { name = {js|From 2n+1 to n|js}
-  ; embedPath = {js|/videos/embed/74b32dae-11c6-4713-be1b-946260196e50|js}
-  ; thumbnailPath = {js|/static/thumbnails/a2042ab9-9025-421a-9eae-176462ac594b.jpg|js}
-  ; description = Some {js|
-OCaml relies on a type-agnostic object representation centred around values which unify odd integers and aligned pointers. The last bit of a value distinguishes the two variants: zero indicates a pointer on the OCaml heap, while one encodes a ta...|js}
-  ; date = {js|2021-08-31T08:30:23.211Z|js}
+  { name = {js|Semgrep : a fast, lightweight, polyglot static analysis tool to find bugs|js}
+  ; embedPath = {js|/videos/embed/c0d07213-1426-46a1-98e0-0b0c4515c841|js}
+  ; thumbnailPath = {js|/static/thumbnails/2ab3961f-4e66-4ec9-b20e-72e25dfbebe4.jpg|js}
+  ; description = Some {js|Semgrep, which stands for “semantic grep,” is a fast, lightweight, polyglot, open source static analysis tool to find bugs and enforce code standards. It is used internally by many companies including Dropbox and Snowflake. Semgrep is also now use...|js}
+  ; date = {js|2021-08-31T08:41:15.492Z|js}
   ; language = {js|English|js}
   ; category = {js|Misc|js}
   };
  
-  { name = {js|Love: a readable language interpreted by a blockchain|js}
-  ; embedPath = {js|/videos/embed/d3b2b31e-1739-406e-8de7-d5f21bc01836|js}
-  ; thumbnailPath = {js|/static/thumbnails/93a6e9ac-2266-408a-81e7-1ebf239233f8.jpg|js}
-  ; description = Some {js|We present Love, a smart contract language embedded in the Dune Network blockchain. It benefits from an OCaml-like syntax and a system-F inspired type system. Love has been used for deploying complex services such as games, ERC20s, atomic swaps, e...|js}
-  ; date = {js|2021-08-27T15:10:17.000Z|js}
-  ; language = {js|English|js}
+  { name = {js|Specialization of Generic Array Accesses After Inlining|js}
+  ; embedPath = {js|/videos/embed/80553916-b90a-4641-93c8-35b000df04c1|js}
+  ; thumbnailPath = {js|/static/thumbnails/1f81fbbf-6fb0-4047-93a1-57759431166a.jpg|js}
+  ; description = None
+  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; language = {js|Unknown|js}
   ; category = {js|Science & Technology|js}
   };
  
-  { name = {js|Opam-bin: Binary Packages with Opam|js}
-  ; embedPath = {js|/videos/embed/a889e4d3-0508-4734-b667-7060b0a253cd|js}
-  ; thumbnailPath = {js|/static/thumbnails/b2325a24-f068-473b-961e-a0b783ae5c39.jpg|js}
-  ; description = Some {js|In this talk, we will present opam-bin, an Opam plugin that builds Binary Opam packages on the fly, to speed-up reinstallation of pack- ages. opam-bin also creates Opam Repositories for these binary pack- ages, to make them easy to share with othe...|js}
-  ; date = {js|2021-08-27T15:01:40.000Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Experiences with Effects in OCaml|js}
-  ; embedPath = {js|/videos/embed/74ece0a8-380f-4e2a-bef5-c6bb9092be89|js}
-  ; thumbnailPath = {js|/static/thumbnails/d48bf7bb-8c46-4d49-a3a6-734bf339343b.jpg|js}
-  ; description = Some {js|The multicore branch of OCaml adds support for effect handlers. In this talk, we report our experiences with effects, both from converting existing code, and from writing new code. Converting the Angstrom parser from a callback style to effects gr...|js}
-  ; date = {js|2021-08-27T14:41:07.000Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|25 Years of OCaml: Xavier Leroy|js}
-  ; embedPath = {js|/videos/embed/e1ee0fc0-50ef-4a1c-894a-17df181424cb|js}
-  ; thumbnailPath = {js|/static/thumbnails/94ead657-79a0-4c10-8435-9e13906a6c44.jpg|js}
-  ; description = Some {js|Professor Xavier Leroy -- the primary original author and leader of the OCaml project -- reflects on 25 years of the OCaml language at his OCaml Workshop 2021 keynote speech.|js}
-  ; date = {js|2021-08-27T13:23:10.199Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Digodoc and Docs|js}
-  ; embedPath = {js|/videos/embed/db6ed2c4-e940-4d5f-82ee-d3d20eb4ceb7|js}
-  ; thumbnailPath = {js|/static/thumbnails/43a418d6-56ec-48f4-852b-0a18ec0789aa.jpg|js}
-  ; description = Some {js|In this talk, we will introduce a new tool called digodoc, that builds a graph of an opam switch, associating files, libraries and opam packages into a cyclic graph of inclusions and dependencies. We will then explain how we used that tool to buil...|js}
-  ; date = {js|2021-08-27T12:09:56.000Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|A Multiverse of Glorious Documentation|js}
-  ; embedPath = {js|/videos/embed/9bb452d6-1829-4dac-a6a2-46b31050c931|js}
-  ; thumbnailPath = {js|/static/thumbnails/6a0a8291-4626-4820-8071-904b3c508345.jpg|js}
-  ; description = Some {js|This talk describes the process of generating documentation for every version of every package that can be built from the opam repository, and how it is presented as a single coherent website that is continuously updated as new packages are releas...|js}
-  ; date = {js|2021-08-27T11:23:36.000Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Continuous Benchmarking for OCaml Projects|js}
-  ; embedPath = {js|/videos/embed/1c994370-1aaa-4db6-b901-d762786e4904|js}
-  ; thumbnailPath = {js|/static/thumbnails/33ab36c3-3650-4c13-9fea-9b5907cf8c0f.jpg|js}
-  ; description = Some {js|Regular CI systems are optimised for workloads that do not require stable performance over time. This makes them unsuitable for running performance benchmarks.
-
-current-bench provides a predictable environment for performance benchmarks and a UI...|js}
-  ; date = {js|2021-08-27T11:20:09.000Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Probabilistic resource limits using StatMemprof|js}
-  ; embedPath = {js|/videos/embed/bc297e85-82dd-4baf-8556-4a3a934978f9|js}
-  ; thumbnailPath = {js|/static/thumbnails/9b4dc06e-1d07-45b8-a21a-1e4f39897fef.jpg|js}
-  ; description = Some {js|The goal of this talk is two-fold. First, we present memprof-limits, a probabilistic implementation of per-thread global memory limits, and per-thread allocation limits, for OCaml 4.12. Then, we will discuss the reasoning about programs in the pre...|js}
-  ; date = {js|2021-08-27T11:08:12.000Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Leveraging Formal Specifications to Generate Fuzzing Suites|js}
-  ; embedPath = {js|/videos/embed/d9a36c9f-1611-42f9-8854-981b1e2d7d75|js}
-  ; thumbnailPath = {js|/static/thumbnails/e5d18bd4-b482-463c-80f8-35d9fbb46b23.jpg|js}
-  ; description = Some {js|When testing a library, developers typically first have to capture the semantics they want to check. They then write the code implementing these tests and find relevant test cases that expose possible misbehaviours.
-
-In this work, we present a t...|js}
-  ; date = {js|2021-08-27T10:40:06.000Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Wibbily Wobbly Timey Camly|js}
-  ; embedPath = {js|/videos/embed/ec641446-823b-40ec-a207-85157a18f88e|js}
-  ; thumbnailPath = {js|/static/thumbnails/2300474a-7615-4c92-9489-9ff5117d8bc7.jpg|js}
-  ; description = Some {js|Time handling is commonly considered a difficult problem by programmers due to myriad standards and complexity of time zone definitions. This also complicates scheduling across multiple time zones especially when one takes Daylight Saving Time int...|js}
-  ; date = {js|2021-08-27T10:37:18.000Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Parafuzz: Coverage-guided Property Fuzzing for Multicore OCaml programs|js}
-  ; embedPath = {js|/videos/embed/c0d591e0-91c9-4eaa-a4d7-c4f514de0a57|js}
-  ; thumbnailPath = {js|/static/thumbnails/b1a67c0a-2eb9-4c9d-97ce-b4dc039da59b.jpg|js}
-  ; description = Some {js|We develop ParaFuzz, an input and concurrency fuzzing tool for Multicore OCaml programs. ParaFuzz builds on top of Crowbar which combines AFL-based grey box fuzzing with QuickCheck and extends it to handle parallelism.
-
-Sumit Padhiyar
-Indian In...|js}
-  ; date = {js|2021-08-27T10:36:13.000Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Deductive Verification of Realistic OCaml Code|js}
-  ; embedPath = {js|/videos/embed/92309d92-8cbf-4545-980c-209c96e42a79|js}
-  ; thumbnailPath = {js|/static/thumbnails/db29d3bf-784c-47f1-bf90-f13fd2a9d530.jpg|js}
-  ; description = Some {js|We present the formal verification of a subset of the Set module from the OCaml standard library. The proof is conducted using Cameleer, a new tool for the deductive verification of OCaml code. Cameleer takes as input an OCaml program, annotated u...|js}
-  ; date = {js|2021-08-27T10:33:38.000Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Adapting the OCaml ecosystem for Multicore OCaml|js}
-  ; embedPath = {js|/videos/embed/629b89a8-bbd5-490d-98b0-d0c740912b02|js}
-  ; thumbnailPath = {js|/static/thumbnails/41212c84-36d6-44fa-b884-2ced79505929.jpg|js}
-  ; description = Some {js|OCaml 5.0 with support for shared-memory parallelism being around the corner, there’s increasing interest in the community to port existing libraries to Multicore. This talk will take the attendees through what the arrival of Multicore means to th...|js}
-  ; date = {js|2021-08-27T10:18:38.000Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|OCaml and Python: Getting the Best of Both Worlds|js}
-  ; embedPath = {js|/videos/embed/9eafdb1e-9be9-4a52-98b4-f4696eda4c18|js}
-  ; thumbnailPath = {js|/static/thumbnails/53db83d1-0763-4dfa-a087-cce3cad1b581.jpg|js}
-  ; description = Some {js|In this talk we present how we expose a wide variety of OCaml libraries and services so that they can be accessed from Python. Our initial use case on the Python side consisted in Jupyter notebooks used to analyse various datasets, these datasets ...|js}
-  ; date = {js|2021-08-27T10:16:54.000Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|GopCaml: A Structural Editor for OCaml|js}
-  ; embedPath = {js|/videos/embed/e0a6e6f2-0d40-4dfc-9308-001c8e0f64d6|js}
-  ; thumbnailPath = {js|/static/thumbnails/729cda51-abb3-4c8d-9d0e-b922e81be518.jpg|js}
-  ; description = Some {js|This talk presents GopCaml-mode, the first structural editing plugin for OCaml. We will give a tour of the main plugin features, discussing the plugin’s internal design and its integration with existing OCaml and GNU Emacs toolchains.
-
-Kiran Gop...|js}
-  ; date = {js|2021-08-27T10:12:58.000Z|js}
+  { name = {js|State of the OCaml Platform|js}
+  ; embedPath = {js|/videos/embed/390ce74c-f85f-477d-8f20-504437409add|js}
+  ; thumbnailPath = {js|/static/thumbnails/33258292-009b-42ee-83d3-9eb4bfb4e048.jpg|js}
+  ; description = None
+  ; date = {js|2018-01-12T00:00:00.000Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
@@ -216,59 +395,6 @@ Kiran Gop...|js}
   ; category = {js|Science & Technology|js}
   };
  
-  { name = {js|OCaml-CI : A Zero-Configuration CI|js}
-  ; embedPath = {js|/videos/embed/0fee79e8-715a-400b-bfcc-34c3610f4890|js}
-  ; thumbnailPath = {js|/static/thumbnails/596f39a9-8654-4922-8bec-6e7ac5dcc319.jpg|js}
-  ; description = Some {js|OCaml-CI
-
-is a CI service for OCaml projects. It
-uses metadata from the project’s opam and dune
-files to work out what to build, and uses caching
-to make builds fast. It automatically tests projects
-against multiple OCaml versions and OS platforms...|js}
-  ; date = {js|2020-08-28T00:00:00.000Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Misc|js}
-  };
- 
-  { name = {js|The final pieces of the OCaml documentation puzzle|js}
-  ; embedPath = {js|/videos/embed/2acebff9-25fa-4733-83cc-620a65b12251|js}
-  ; thumbnailPath = {js|/static/thumbnails/c877a501-c705-44f7-8826-e7ce846a5e42.jpg|js}
-  ; description = Some {js|Rendering OCaml document is widely known as a very difficult task: The ever-evolving OCaml module system is extremely rich and can include complex set of inter-dependencies that are both difficult to compute and to render in a concise document. It...|js}
-  ; date = {js|2020-08-28T00:00:00.000Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Misc|js}
-  };
- 
-  { name = {js|API migration: compare transformed|js}
-  ; embedPath = {js|/videos/embed/c46b925b-bd77-404f-ac5d-5dab65047529|js}
-  ; thumbnailPath = {js|/static/thumbnails/eef64419-3c34-4c15-9419-edcbc455e54d.jpg|js}
-  ; description = Some {js|In this talk we describe our experience in using an automatic API-migration strategy dedicated at changing the signatures of OCaml functions, using the Rotor refactoring tool for OCaml. We perform a case study on open source Jane Street libraries ...|js}
-  ; date = {js|2020-08-28T00:00:00.000Z|js}
-  ; language = {js|Unknown|js}
-  ; category = {js|Misc|js}
-  };
- 
-  { name = {js|Parallelising your OCaml Code with Multicore OCaml|js}
-  ; embedPath = {js|/videos/embed/ce20839e-4bfc-4d74-925b-485a6b052ddf|js}
-  ; thumbnailPath = {js|/static/thumbnails/30bc6019-ecab-40e5-a7b6-c294ac9a7344.jpg|js}
-  ; description = Some {js|Slides, speaker notes and runnable examples mentioned in this talk are available at: https://github.com/ocaml-multicore/ocaml2020-workshop-parallel
-
-With the availability of multicore variants of the recent OCaml versions (4.10 and 4.11) that main...|js}
-  ; date = {js|2020-08-28T00:00:00.000Z|js}
-  ; language = {js|Unknown|js}
-  ; category = {js|Misc|js}
-  };
- 
-  { name = {js|A Simple State-Machine Framework for Property-Based Testing in OCaml|js}
-  ; embedPath = {js|/videos/embed/08b429ea-2eb8-427d-a625-5495f4ee0fef|js}
-  ; thumbnailPath = {js|/static/thumbnails/316ddad9-dbc3-4d46-9f43-5da72689e93b.jpg|js}
-  ; description = Some {js|Since their inception, state-machine frameworks have proven their worth by finding defects in everything from the underlying AUTOSAR components of Volvo cars to digital invoicing systems. These case studies were carried out with Erlang’s commercia...|js}
-  ; date = {js|2020-08-28T00:00:00.000Z|js}
-  ; language = {js|Unknown|js}
-  ; category = {js|Misc|js}
-  };
- 
   { name = {js|The ImpFS filesystem|js}
   ; embedPath = {js|/videos/embed/28545b27-4637-47a5-8edd-6b904daef19c|js}
   ; thumbnailPath = {js|/static/thumbnails/dde19660-653d-4dc3-9e81-54b2e3ab22a2.jpg|js}
@@ -276,69 +402,6 @@ With the availability of multicore variants of the recent OCaml versions (4.10 a
   ; date = {js|2020-08-28T00:00:00.000Z|js}
   ; language = {js|Unknown|js}
   ; category = {js|Misc|js}
-  };
- 
-  { name = {js|Irmin v2|js}
-  ; embedPath = {js|/videos/embed/53e497b0-898f-4c85-8da9-39f65ef0e0b1|js}
-  ; thumbnailPath = {js|/static/thumbnails/138e7c05-185b-4e54-95d0-d15018905a39.jpg|js}
-  ; description = Some {js|Irmin is an OCaml library for building distributed databases with the same design principles as Git. Existing Git users will find many familiar features: branching/merging, immutable causal history for all changes, and the ability to restore to an...|js}
-  ; date = {js|2020-08-28T00:00:00.000Z|js}
-  ; language = {js|Unknown|js}
-  ; category = {js|Misc|js}
-  };
- 
-  { name = {js|AD-OCaml: Algorithmic Differentiation for OCaml|js}
-  ; embedPath = {js|/videos/embed/c9e85690-732f-4b03-836f-2ee0fd8f0658|js}
-  ; thumbnailPath = {js|/static/thumbnails/eb972fd2-668e-4998-a798-e9fbdcadba20.jpg|js}
-  ; description = Some {js|AD-OCaml is a library framework for calculating mathematically exact derivatives and deep power series approximations of almost arbitrary OCaml programs via algorithmic differentiation. Unlike similar frameworks, this includes programs with side e...|js}
-  ; date = {js|2020-08-28T00:00:00.000Z|js}
-  ; language = {js|Unknown|js}
-  ; category = {js|Misc|js}
-  };
- 
-  { name = {js|OCaml Under The Hood: SmartPy|js}
-  ; embedPath = {js|/videos/embed/7446ad4d-4ae2-4e1a-bc38-af8f71e8ebd8|js}
-  ; thumbnailPath = {js|/static/thumbnails/e1ac5b07-3648-40c1-b62c-5e88471741dc.jpg|js}
-  ; description = Some {js|SmartPy is a complete system to develop smart-contracts for the Tezos blockchain. It is an embedded EDSL in python to write contracts and their test scenarios. It includes an online IDE, a chain explorer, and a command-line interface. Python is us...|js}
-  ; date = {js|2020-08-28T00:00:00.000Z|js}
-  ; language = {js|Unknown|js}
-  ; category = {js|Misc|js}
-  };
- 
-  { name = {js|A Declarative Syntax Definition for OCaml|js}
-  ; embedPath = {js|/videos/embed/a5b86864-8e43-4138-b6d6-ed48d2d4b63d|js}
-  ; thumbnailPath = {js|/static/thumbnails/92c0a0e3-5326-42aa-86a3-6adb3927e111.jpg|js}
-  ; description = Some {js|In this talk, we present our work on a syntax definition for the OCaml language in the syntax definition formalism SDF3. SDF3 supports the high-level definition of concrete and abstract syntax through declarative disambiguation and definition of c...|js}
-  ; date = {js|2020-08-28T00:00:00.000Z|js}
-  ; language = {js|Unknown|js}
-  ; category = {js|Misc|js}
-  };
- 
-  { name = {js|LexiFi Runtime Types|js}
-  ; embedPath = {js|/videos/embed/cc7e3242-0bef-448a-aa13-8827bba933e3|js}
-  ; thumbnailPath = {js|/static/thumbnails/1d43d8b4-87d1-4398-b925-10a42460b8dc.jpg|js}
-  ; description = Some {js|OCaml programmers make deliberate use of abstract data types for composing safe and reliable software systems. The OCaml compiler relies on the invariants imposed by the type system to produce efficient and compact runtime data representations. Be...|js}
-  ; date = {js|2020-08-28T00:00:00.000Z|js}
-  ; language = {js|Unknown|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Types in Amber|js}
-  ; embedPath = {js|/videos/embed/99b3dc75-9f93-4677-9f8b-076546725512|js}
-  ; thumbnailPath = {js|/static/thumbnails/acd50ed1-43cf-45fd-a55e-9c40a6bf58ba.jpg|js}
-  ; description = Some {js|Coda is a new cryptocurrency that uses zk-SNARKs to dramatically reduce the size of data needed by nodes running its protocol. Nodes communicate in a format automatically derived from type definitions in OCaml source files. As the Coda software ev...|js}
-  ; date = {js|2020-08-28T00:00:00.000Z|js}
-  ; language = {js|Unknown|js}
-  ; category = {js|Misc|js}
-  };
- 
-  { name = {js|OCaml-CI : A Zero-Configuration CI|js}
-  ; embedPath = {js|/videos/embed/da88d6ac-7ba1-4261-9308-d03fe21e35b9|js}
-  ; thumbnailPath = {js|/static/thumbnails/1c22a14e-f067-4d4e-8e26-027cc6d8a491.jpg|js}
-  ; description = Some {js|OCaml-CI1 is a CI service for OCaml projects. It uses metadata from the project’s opam and dune files to work out what to build, and uses caching to make builds fast. It automatically tests projects against multiple OCaml versions and OS platforms...|js}
-  ; date = {js|2020-08-28T00:00:00.000Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
   };
  
   { name = {js|The OCaml Platform 1.0 - Reason ML|js}
@@ -349,60 +412,6 @@ With the availability of multicore variants of the recent OCaml versions (4.10 a
 We keep being told ReasonML can compile to native and do interop with OCaml, and that there's a wealth of existing code and tools we can draw into our applications - but how do we get there?
 This video will ...|js}
   ; date = {js|2018-12-11T00:00:00.000Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|State of the OCaml Platform|js}
-  ; embedPath = {js|/videos/embed/390ce74c-f85f-477d-8f20-504437409add|js}
-  ; thumbnailPath = {js|/static/thumbnails/33258292-009b-42ee-83d3-9eb4bfb4e048.jpg|js}
-  ; description = None
-  ; date = {js|2018-01-12T00:00:00.000Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Towards A Debugger for Native Code OCaml|js}
-  ; embedPath = {js|/videos/embed/b76f3301-261d-44f3-97ec-1910b45f6969|js}
-  ; thumbnailPath = {js|/static/thumbnails/93ea327e-5e8b-4844-b237-75719a7256b9.jpg|js}
-  ; description = None
-  ; date = {js|2015-09-18T00:00:00.000Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Operf: Benchmarking the OCaml Compiler|js}
-  ; embedPath = {js|/videos/embed/5a4a6c12-3cb1-40d2-a663-25f294e12555|js}
-  ; thumbnailPath = {js|/static/thumbnails/c2b5c90a-9c9e-4058-94a1-15525795a01a.jpg|js}
-  ; description = None
-  ; date = {js|2015-09-18T00:00:00.000Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Core Time stamp counter: A fast high resolution time source|js}
-  ; embedPath = {js|/videos/embed/75b4d60f-3e37-40bd-b025-f39dcce0c42c|js}
-  ; thumbnailPath = {js|/static/thumbnails/43248673-6478-4e96-b8ac-cd415d85569b.jpg|js}
-  ; description = None
-  ; date = {js|2015-09-18T00:00:00.000Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Specialization of Generic Array Accesses After Inlining|js}
-  ; embedPath = {js|/videos/embed/80553916-b90a-4641-93c8-35b000df04c1|js}
-  ; thumbnailPath = {js|/static/thumbnails/1f81fbbf-6fb0-4047-93a1-57759431166a.jpg|js}
-  ; description = None
-  ; date = {js|2015-09-18T00:00:00.000Z|js}
-  ; language = {js|Unknown|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Inline Assembly in OCaml|js}
-  ; embedPath = {js|/videos/embed/632f520f-8f83-4b6f-89f1-5cde088436c7|js}
-  ; thumbnailPath = {js|/static/thumbnails/5d2f65d1-6129-4206-832b-c3d4bab410df.jpg|js}
-  ; description = None
-  ; date = {js|2015-09-18T00:00:00.000Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
@@ -425,47 +434,38 @@ This video will ...|js}
   ; category = {js|Science & Technology|js}
   };
  
-  { name = {js|Global Semantic Analysis on OCaml programs|js}
-  ; embedPath = {js|/videos/embed/51e4bdf0-50f7-4b13-8514-2d62b5341066|js}
-  ; thumbnailPath = {js|/static/thumbnails/8255d370-e621-44bc-b7c3-6dd39fab4d1d.jpg|js}
+  { name = {js|The final pieces of the OCaml documentation puzzle|js}
+  ; embedPath = {js|/videos/embed/2acebff9-25fa-4733-83cc-620a65b12251|js}
+  ; thumbnailPath = {js|/static/thumbnails/c877a501-c705-44f7-8826-e7ce846a5e42.jpg|js}
+  ; description = Some {js|Rendering OCaml document is widely known as a very difficult task: The ever-evolving OCaml module system is extremely rich and can include complex set of inter-dependencies that are both difficult to compute and to render in a concise document. It...|js}
+  ; date = {js|2020-08-28T00:00:00.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Misc|js}
+  };
+ 
+  { name = {js|Towards A Debugger for Native Code OCaml|js}
+  ; embedPath = {js|/videos/embed/b76f3301-261d-44f3-97ec-1910b45f6969|js}
+  ; thumbnailPath = {js|/static/thumbnails/93ea327e-5e8b-4844-b237-75719a7256b9.jpg|js}
   ; description = None
   ; date = {js|2015-09-18T00:00:00.000Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
  
-  { name = {js|Effective Concurrency through Algebraic Effects|js}
-  ; embedPath = {js|/videos/embed/e9f6c837-1435-4349-af0f-07d22d1c11ea|js}
-  ; thumbnailPath = {js|/static/thumbnails/1de58bd2-d2f9-428c-8b8c-97b48d6d2c7e.jpg|js}
-  ; description = None
-  ; date = {js|2015-09-18T00:00:00.000Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|A review of the growth of the OCaml community|js}
-  ; embedPath = {js|/videos/embed/f9d0b637-8aec-4bff-8c32-cd16b58023b6|js}
-  ; thumbnailPath = {js|/static/thumbnails/e573402b-1350-4aa7-a9ba-0e1c51198fb4.jpg|js}
-  ; description = None
-  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  { name = {js|Types in Amber|js}
+  ; embedPath = {js|/videos/embed/99b3dc75-9f93-4677-9f8b-076546725512|js}
+  ; thumbnailPath = {js|/static/thumbnails/acd50ed1-43cf-45fd-a55e-9c40a6bf58ba.jpg|js}
+  ; description = Some {js|Coda is a new cryptocurrency that uses zk-SNARKs to dramatically reduce the size of data needed by nodes running its protocol. Nodes communicate in a format automatically derived from type definitions in OCaml source files. As the Coda software ev...|js}
+  ; date = {js|2020-08-28T00:00:00.000Z|js}
   ; language = {js|Unknown|js}
-  ; category = {js|Science & Technology|js}
+  ; category = {js|Misc|js}
   };
  
-  { name = {js|Persistent Networking with Irmin and MirageOS|js}
-  ; embedPath = {js|/videos/embed/97dd9634-28e4-4066-96e4-9c2036ee4bb2|js}
-  ; thumbnailPath = {js|/static/thumbnails/46ba8c5d-0f4a-427e-8e76-0c58cb0e70a7.jpg|js}
-  ; description = None
-  ; date = {js|2015-09-18T00:00:00.000Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Ketrew and Biokepi|js}
-  ; embedPath = {js|/videos/embed/f3dcee35-bc04-453a-ba35-7aec90599661|js}
-  ; thumbnailPath = {js|/static/thumbnails/0a36e8ce-c415-4191-ad5b-6ef2eb23db4e.jpg|js}
-  ; description = None
-  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  { name = {js|Wibbily Wobbly Timey Camly|js}
+  ; embedPath = {js|/videos/embed/ec641446-823b-40ec-a207-85157a18f88e|js}
+  ; thumbnailPath = {js|/static/thumbnails/2300474a-7615-4c92-9489-9ff5117d8bc7.jpg|js}
+  ; description = Some {js|Time handling is commonly considered a difficult problem by programmers due to myriad standards and complexity of time zone definitions. This also complicates scheduling across multiple time zones especially when one takes Daylight Saving Time int...|js}
+  ; date = {js|2021-08-27T10:37:18.000Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   }]

--- a/src/ood/watch.ml
+++ b/src/ood/watch.ml
@@ -4,19 +4,214 @@
   { name: string;
     embedPath : string;
     thumbnailPath : string;
-    description : string;
-    year : int;
+    description : string option;
+    date : string;
     language : string;
     category : string;
   }
   
 let all = 
 [
+  { name = {js|Semgrep : a fast, lightweight, polyglot static analysis tool to find bugs|js}
+  ; embedPath = {js|/videos/embed/c0d07213-1426-46a1-98e0-0b0c4515c841|js}
+  ; thumbnailPath = {js|/static/thumbnails/2ab3961f-4e66-4ec9-b20e-72e25dfbebe4.jpg|js}
+  ; description = Some {js|Semgrep, which stands for “semantic grep,” is a fast, lightweight, polyglot, open source static analysis tool to find bugs and enforce code standards. It is used internally by many companies including Dropbox and Snowflake. Semgrep is also now use...|js}
+  ; date = {js|2021-08-31T08:41:15.492Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Misc|js}
+  };
+ 
+  { name = {js|Binary Analysis Platform|js}
+  ; embedPath = {js|/videos/embed/8dc2d8d3-c140-4c3d-a8fe-a6fcf6fba988|js}
+  ; thumbnailPath = {js|/static/thumbnails/390cd7dd-4578-4162-bae0-6c218cb5ebde.jpg|js}
+  ; description = Some {js|We present Binary Analysis Platform (BAP), a representation-agnostic program analysis framework for binaries that can leverage existing tools, libraries, and frameworks, no matter which intermediate representation (IR) they use. In BAP, a new IR c...|js}
+  ; date = {js|2021-08-31T08:39:55.774Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Misc|js}
+  };
+ 
+  { name = {js|Property-Based Testing for OCaml through Coq|js}
+  ; embedPath = {js|/videos/embed/9324fba4-2482-4bab-bfdd-b8881b3ed94a|js}
+  ; thumbnailPath = {js|/static/thumbnails/d7e22bba-cda1-4c2b-9368-9b2c1643e751.jpg|js}
+  ; description = Some {js|We will present a property-based testing framework for OCaml that leverages the power of QuickChick, a popular and mature testing plugin for the Coq proof assistant, by automatically constructing a extraction-based shim between OCaml and Coq. That...|js}
+  ; date = {js|2021-08-31T08:37:00.571Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Misc|js}
+  };
+ 
+  { name = {js|Safe Protocol Updates via Propositional Logic|js}
+  ; embedPath = {js|/videos/embed/c6176f51-0277-46f0-937b-1e2721044492|js}
+  ; thumbnailPath = {js|/static/thumbnails/a89a3483-274a-44f1-9a38-c679f6b12196.jpg|js}
+  ; description = Some {js|If values of a given type are stored on disk, or are sent between different executables, then changing that type or its serialization can result in versioning issues.
+Often such issues are resolved by either making the deserializer more permissiv...|js}
+  ; date = {js|2021-08-31T08:34:54.707Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Misc|js}
+  };
+ 
+  { name = {js|From 2n+1 to n|js}
+  ; embedPath = {js|/videos/embed/74b32dae-11c6-4713-be1b-946260196e50|js}
+  ; thumbnailPath = {js|/static/thumbnails/a2042ab9-9025-421a-9eae-176462ac594b.jpg|js}
+  ; description = Some {js|
+OCaml relies on a type-agnostic object representation centred around values which unify odd integers and aligned pointers. The last bit of a value distinguishes the two variants: zero indicates a pointer on the OCaml heap, while one encodes a ta...|js}
+  ; date = {js|2021-08-31T08:30:23.211Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Misc|js}
+  };
+ 
+  { name = {js|Love: a readable language interpreted by a blockchain|js}
+  ; embedPath = {js|/videos/embed/d3b2b31e-1739-406e-8de7-d5f21bc01836|js}
+  ; thumbnailPath = {js|/static/thumbnails/93a6e9ac-2266-408a-81e7-1ebf239233f8.jpg|js}
+  ; description = Some {js|We present Love, a smart contract language embedded in the Dune Network blockchain. It benefits from an OCaml-like syntax and a system-F inspired type system. Love has been used for deploying complex services such as games, ERC20s, atomic swaps, e...|js}
+  ; date = {js|2021-08-27T15:10:17.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Opam-bin: Binary Packages with Opam|js}
+  ; embedPath = {js|/videos/embed/a889e4d3-0508-4734-b667-7060b0a253cd|js}
+  ; thumbnailPath = {js|/static/thumbnails/b2325a24-f068-473b-961e-a0b783ae5c39.jpg|js}
+  ; description = Some {js|In this talk, we will present opam-bin, an Opam plugin that builds Binary Opam packages on the fly, to speed-up reinstallation of pack- ages. opam-bin also creates Opam Repositories for these binary pack- ages, to make them easy to share with othe...|js}
+  ; date = {js|2021-08-27T15:01:40.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Experiences with Effects in OCaml|js}
+  ; embedPath = {js|/videos/embed/74ece0a8-380f-4e2a-bef5-c6bb9092be89|js}
+  ; thumbnailPath = {js|/static/thumbnails/d48bf7bb-8c46-4d49-a3a6-734bf339343b.jpg|js}
+  ; description = Some {js|The multicore branch of OCaml adds support for effect handlers. In this talk, we report our experiences with effects, both from converting existing code, and from writing new code. Converting the Angstrom parser from a callback style to effects gr...|js}
+  ; date = {js|2021-08-27T14:41:07.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|25 Years of OCaml: Xavier Leroy|js}
+  ; embedPath = {js|/videos/embed/e1ee0fc0-50ef-4a1c-894a-17df181424cb|js}
+  ; thumbnailPath = {js|/static/thumbnails/94ead657-79a0-4c10-8435-9e13906a6c44.jpg|js}
+  ; description = Some {js|Professor Xavier Leroy -- the primary original author and leader of the OCaml project -- reflects on 25 years of the OCaml language at his OCaml Workshop 2021 keynote speech.|js}
+  ; date = {js|2021-08-27T13:23:10.199Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Digodoc and Docs|js}
+  ; embedPath = {js|/videos/embed/db6ed2c4-e940-4d5f-82ee-d3d20eb4ceb7|js}
+  ; thumbnailPath = {js|/static/thumbnails/43a418d6-56ec-48f4-852b-0a18ec0789aa.jpg|js}
+  ; description = Some {js|In this talk, we will introduce a new tool called digodoc, that builds a graph of an opam switch, associating files, libraries and opam packages into a cyclic graph of inclusions and dependencies. We will then explain how we used that tool to buil...|js}
+  ; date = {js|2021-08-27T12:09:56.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|A Multiverse of Glorious Documentation|js}
+  ; embedPath = {js|/videos/embed/9bb452d6-1829-4dac-a6a2-46b31050c931|js}
+  ; thumbnailPath = {js|/static/thumbnails/6a0a8291-4626-4820-8071-904b3c508345.jpg|js}
+  ; description = Some {js|This talk describes the process of generating documentation for every version of every package that can be built from the opam repository, and how it is presented as a single coherent website that is continuously updated as new packages are releas...|js}
+  ; date = {js|2021-08-27T11:23:36.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Continuous Benchmarking for OCaml Projects|js}
+  ; embedPath = {js|/videos/embed/1c994370-1aaa-4db6-b901-d762786e4904|js}
+  ; thumbnailPath = {js|/static/thumbnails/33ab36c3-3650-4c13-9fea-9b5907cf8c0f.jpg|js}
+  ; description = Some {js|Regular CI systems are optimised for workloads that do not require stable performance over time. This makes them unsuitable for running performance benchmarks.
+
+current-bench provides a predictable environment for performance benchmarks and a UI...|js}
+  ; date = {js|2021-08-27T11:20:09.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Probabilistic resource limits using StatMemprof|js}
+  ; embedPath = {js|/videos/embed/bc297e85-82dd-4baf-8556-4a3a934978f9|js}
+  ; thumbnailPath = {js|/static/thumbnails/9b4dc06e-1d07-45b8-a21a-1e4f39897fef.jpg|js}
+  ; description = Some {js|The goal of this talk is two-fold. First, we present memprof-limits, a probabilistic implementation of per-thread global memory limits, and per-thread allocation limits, for OCaml 4.12. Then, we will discuss the reasoning about programs in the pre...|js}
+  ; date = {js|2021-08-27T11:08:12.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Leveraging Formal Specifications to Generate Fuzzing Suites|js}
+  ; embedPath = {js|/videos/embed/d9a36c9f-1611-42f9-8854-981b1e2d7d75|js}
+  ; thumbnailPath = {js|/static/thumbnails/e5d18bd4-b482-463c-80f8-35d9fbb46b23.jpg|js}
+  ; description = Some {js|When testing a library, developers typically first have to capture the semantics they want to check. They then write the code implementing these tests and find relevant test cases that expose possible misbehaviours.
+
+In this work, we present a t...|js}
+  ; date = {js|2021-08-27T10:40:06.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Wibbily Wobbly Timey Camly|js}
+  ; embedPath = {js|/videos/embed/ec641446-823b-40ec-a207-85157a18f88e|js}
+  ; thumbnailPath = {js|/static/thumbnails/2300474a-7615-4c92-9489-9ff5117d8bc7.jpg|js}
+  ; description = Some {js|Time handling is commonly considered a difficult problem by programmers due to myriad standards and complexity of time zone definitions. This also complicates scheduling across multiple time zones especially when one takes Daylight Saving Time int...|js}
+  ; date = {js|2021-08-27T10:37:18.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Parafuzz: Coverage-guided Property Fuzzing for Multicore OCaml programs|js}
+  ; embedPath = {js|/videos/embed/c0d591e0-91c9-4eaa-a4d7-c4f514de0a57|js}
+  ; thumbnailPath = {js|/static/thumbnails/b1a67c0a-2eb9-4c9d-97ce-b4dc039da59b.jpg|js}
+  ; description = Some {js|We develop ParaFuzz, an input and concurrency fuzzing tool for Multicore OCaml programs. ParaFuzz builds on top of Crowbar which combines AFL-based grey box fuzzing with QuickCheck and extends it to handle parallelism.
+
+Sumit Padhiyar
+Indian In...|js}
+  ; date = {js|2021-08-27T10:36:13.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Deductive Verification of Realistic OCaml Code|js}
+  ; embedPath = {js|/videos/embed/92309d92-8cbf-4545-980c-209c96e42a79|js}
+  ; thumbnailPath = {js|/static/thumbnails/db29d3bf-784c-47f1-bf90-f13fd2a9d530.jpg|js}
+  ; description = Some {js|We present the formal verification of a subset of the Set module from the OCaml standard library. The proof is conducted using Cameleer, a new tool for the deductive verification of OCaml code. Cameleer takes as input an OCaml program, annotated u...|js}
+  ; date = {js|2021-08-27T10:33:38.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Adapting the OCaml ecosystem for Multicore OCaml|js}
+  ; embedPath = {js|/videos/embed/629b89a8-bbd5-490d-98b0-d0c740912b02|js}
+  ; thumbnailPath = {js|/static/thumbnails/41212c84-36d6-44fa-b884-2ced79505929.jpg|js}
+  ; description = Some {js|OCaml 5.0 with support for shared-memory parallelism being around the corner, there’s increasing interest in the community to port existing libraries to Multicore. This talk will take the attendees through what the arrival of Multicore means to th...|js}
+  ; date = {js|2021-08-27T10:18:38.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|OCaml and Python: Getting the Best of Both Worlds|js}
+  ; embedPath = {js|/videos/embed/9eafdb1e-9be9-4a52-98b4-f4696eda4c18|js}
+  ; thumbnailPath = {js|/static/thumbnails/53db83d1-0763-4dfa-a087-cce3cad1b581.jpg|js}
+  ; description = Some {js|In this talk we present how we expose a wide variety of OCaml libraries and services so that they can be accessed from Python. Our initial use case on the Python side consisted in Jupyter notebooks used to analyse various datasets, these datasets ...|js}
+  ; date = {js|2021-08-27T10:16:54.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|GopCaml: A Structural Editor for OCaml|js}
+  ; embedPath = {js|/videos/embed/e0a6e6f2-0d40-4dfc-9308-001c8e0f64d6|js}
+  ; thumbnailPath = {js|/static/thumbnails/729cda51-abb3-4c8d-9d0e-b922e81be518.jpg|js}
+  ; description = Some {js|This talk presents GopCaml-mode, the first structural editing plugin for OCaml. We will give a tour of the main plugin features, discussing the plugin’s internal design and its integration with existing OCaml and GNU Emacs toolchains.
+
+Kiran Gop...|js}
+  ; date = {js|2021-08-27T10:12:58.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
   { name = {js|State of the OCaml Platform 2020|js}
   ; embedPath = {js|/videos/embed/0e2070fd-798b-47f7-8e69-ef75e967e516|js}
   ; thumbnailPath = {js|/static/thumbnails/4fd6a51f-686c-4f6f-8026-83692304b432.jpg|js}
-  ; description = {js|This talk covers: - Integrated Development Environments - Next Steps for the OCaml Platform - Plans for 2020-2021|js}
-  ; year = 2020
+  ; description = Some {js|This talk covers:
+
+- Integrated Development Environments
+- Next Steps for the OCaml Platform
+- Plans for 2020-2021|js}
+  ; date = {js|2020-08-28T00:00:00.000Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
@@ -24,14 +219,14 @@ let all =
   { name = {js|OCaml-CI : A Zero-Configuration CI|js}
   ; embedPath = {js|/videos/embed/0fee79e8-715a-400b-bfcc-34c3610f4890|js}
   ; thumbnailPath = {js|/static/thumbnails/596f39a9-8654-4922-8bec-6e7ac5dcc319.jpg|js}
-  ; description = {js|OCaml-CI
+  ; description = Some {js|OCaml-CI
 
 is a CI service for OCaml projects. It
 uses metadata from the project’s opam and dune
 files to work out what to build, and uses caching
 to make builds fast. It automatically tests projects
 against multiple OCaml versions and OS platforms...|js}
-  ; year = 2020
+  ; date = {js|2020-08-28T00:00:00.000Z|js}
   ; language = {js|English|js}
   ; category = {js|Misc|js}
   };
@@ -39,8 +234,8 @@ against multiple OCaml versions and OS platforms...|js}
   { name = {js|The final pieces of the OCaml documentation puzzle|js}
   ; embedPath = {js|/videos/embed/2acebff9-25fa-4733-83cc-620a65b12251|js}
   ; thumbnailPath = {js|/static/thumbnails/c877a501-c705-44f7-8826-e7ce846a5e42.jpg|js}
-  ; description = {js|Rendering OCaml document is widely known as a very difficult task: The ever-evolving OCaml module system is extremely rich and can include complex set of inter-dependencies that are both difficult to compute and to render in a concise document. It...|js}
-  ; year = 2020
+  ; description = Some {js|Rendering OCaml document is widely known as a very difficult task: The ever-evolving OCaml module system is extremely rich and can include complex set of inter-dependencies that are both difficult to compute and to render in a concise document. It...|js}
+  ; date = {js|2020-08-28T00:00:00.000Z|js}
   ; language = {js|English|js}
   ; category = {js|Misc|js}
   };
@@ -48,8 +243,8 @@ against multiple OCaml versions and OS platforms...|js}
   { name = {js|API migration: compare transformed|js}
   ; embedPath = {js|/videos/embed/c46b925b-bd77-404f-ac5d-5dab65047529|js}
   ; thumbnailPath = {js|/static/thumbnails/eef64419-3c34-4c15-9419-edcbc455e54d.jpg|js}
-  ; description = {js|In this talk we describe our experience in using an automatic API-migration strategy dedicated at changing the signatures of OCaml functions, using the Rotor refactoring tool for OCaml. We perform a case study on open source Jane Street libraries ...|js}
-  ; year = 2020
+  ; description = Some {js|In this talk we describe our experience in using an automatic API-migration strategy dedicated at changing the signatures of OCaml functions, using the Rotor refactoring tool for OCaml. We perform a case study on open source Jane Street libraries ...|js}
+  ; date = {js|2020-08-28T00:00:00.000Z|js}
   ; language = {js|Unknown|js}
   ; category = {js|Misc|js}
   };
@@ -57,8 +252,10 @@ against multiple OCaml versions and OS platforms...|js}
   { name = {js|Parallelising your OCaml Code with Multicore OCaml|js}
   ; embedPath = {js|/videos/embed/ce20839e-4bfc-4d74-925b-485a6b052ddf|js}
   ; thumbnailPath = {js|/static/thumbnails/30bc6019-ecab-40e5-a7b6-c294ac9a7344.jpg|js}
-  ; description = {js|Slides, speaker notes and runnable examples mentioned in this talk are available at: https://github.com/ocaml-multicore/ocaml2020-workshop-parallel With the availability of multicore variants of the recent OCaml versions (4.10 and 4.11) that main...|js}
-  ; year = 2020
+  ; description = Some {js|Slides, speaker notes and runnable examples mentioned in this talk are available at: https://github.com/ocaml-multicore/ocaml2020-workshop-parallel
+
+With the availability of multicore variants of the recent OCaml versions (4.10 and 4.11) that main...|js}
+  ; date = {js|2020-08-28T00:00:00.000Z|js}
   ; language = {js|Unknown|js}
   ; category = {js|Misc|js}
   };
@@ -66,8 +263,8 @@ against multiple OCaml versions and OS platforms...|js}
   { name = {js|A Simple State-Machine Framework for Property-Based Testing in OCaml|js}
   ; embedPath = {js|/videos/embed/08b429ea-2eb8-427d-a625-5495f4ee0fef|js}
   ; thumbnailPath = {js|/static/thumbnails/316ddad9-dbc3-4d46-9f43-5da72689e93b.jpg|js}
-  ; description = {js|Since their inception, state-machine frameworks have proven their worth by finding defects in everything from the underlying AUTOSAR components of Volvo cars to digital invoicing systems. These case studies were carried out with Erlang’s commercia...|js}
-  ; year = 2020
+  ; description = Some {js|Since their inception, state-machine frameworks have proven their worth by finding defects in everything from the underlying AUTOSAR components of Volvo cars to digital invoicing systems. These case studies were carried out with Erlang’s commercia...|js}
+  ; date = {js|2020-08-28T00:00:00.000Z|js}
   ; language = {js|Unknown|js}
   ; category = {js|Misc|js}
   };
@@ -75,8 +272,8 @@ against multiple OCaml versions and OS platforms...|js}
   { name = {js|The ImpFS filesystem|js}
   ; embedPath = {js|/videos/embed/28545b27-4637-47a5-8edd-6b904daef19c|js}
   ; thumbnailPath = {js|/static/thumbnails/dde19660-653d-4dc3-9e81-54b2e3ab22a2.jpg|js}
-  ; description = {js|This proposal describes a presentation to be given at the OCaml’20 workshop. The presentation will cover a new OCaml filesystem, ImpFS, and the related libraries. The filesystem makes use of a B-tree library presented at OCaml’17, and a key-value ...|js}
-  ; year = 2020
+  ; description = Some {js|This proposal describes a presentation to be given at the OCaml’20 workshop. The presentation will cover a new OCaml filesystem, ImpFS, and the related libraries. The filesystem makes use of a B-tree library presented at OCaml’17, and a key-value ...|js}
+  ; date = {js|2020-08-28T00:00:00.000Z|js}
   ; language = {js|Unknown|js}
   ; category = {js|Misc|js}
   };
@@ -84,8 +281,8 @@ against multiple OCaml versions and OS platforms...|js}
   { name = {js|Irmin v2|js}
   ; embedPath = {js|/videos/embed/53e497b0-898f-4c85-8da9-39f65ef0e0b1|js}
   ; thumbnailPath = {js|/static/thumbnails/138e7c05-185b-4e54-95d0-d15018905a39.jpg|js}
-  ; description = {js|Irmin is an OCaml library for building distributed databases with the same design principles as Git. Existing Git users will find many familiar features: branching/merging, immutable causal history for all changes, and the ability to restore to an...|js}
-  ; year = 2020
+  ; description = Some {js|Irmin is an OCaml library for building distributed databases with the same design principles as Git. Existing Git users will find many familiar features: branching/merging, immutable causal history for all changes, and the ability to restore to an...|js}
+  ; date = {js|2020-08-28T00:00:00.000Z|js}
   ; language = {js|Unknown|js}
   ; category = {js|Misc|js}
   };
@@ -93,8 +290,8 @@ against multiple OCaml versions and OS platforms...|js}
   { name = {js|AD-OCaml: Algorithmic Differentiation for OCaml|js}
   ; embedPath = {js|/videos/embed/c9e85690-732f-4b03-836f-2ee0fd8f0658|js}
   ; thumbnailPath = {js|/static/thumbnails/eb972fd2-668e-4998-a798-e9fbdcadba20.jpg|js}
-  ; description = {js|AD-OCaml is a library framework for calculating mathematically exact derivatives and deep power series approximations of almost arbitrary OCaml programs via algorithmic differentiation. Unlike similar frameworks, this includes programs with side e...|js}
-  ; year = 2020
+  ; description = Some {js|AD-OCaml is a library framework for calculating mathematically exact derivatives and deep power series approximations of almost arbitrary OCaml programs via algorithmic differentiation. Unlike similar frameworks, this includes programs with side e...|js}
+  ; date = {js|2020-08-28T00:00:00.000Z|js}
   ; language = {js|Unknown|js}
   ; category = {js|Misc|js}
   };
@@ -102,8 +299,8 @@ against multiple OCaml versions and OS platforms...|js}
   { name = {js|OCaml Under The Hood: SmartPy|js}
   ; embedPath = {js|/videos/embed/7446ad4d-4ae2-4e1a-bc38-af8f71e8ebd8|js}
   ; thumbnailPath = {js|/static/thumbnails/e1ac5b07-3648-40c1-b62c-5e88471741dc.jpg|js}
-  ; description = {js|SmartPy is a complete system to develop smart-contracts for the Tezos blockchain. It is an embedded EDSL in python to write contracts and their test scenarios. It includes an online IDE, a chain explorer, and a command-line interface. Python is us...|js}
-  ; year = 2020
+  ; description = Some {js|SmartPy is a complete system to develop smart-contracts for the Tezos blockchain. It is an embedded EDSL in python to write contracts and their test scenarios. It includes an online IDE, a chain explorer, and a command-line interface. Python is us...|js}
+  ; date = {js|2020-08-28T00:00:00.000Z|js}
   ; language = {js|Unknown|js}
   ; category = {js|Misc|js}
   };
@@ -111,8 +308,8 @@ against multiple OCaml versions and OS platforms...|js}
   { name = {js|A Declarative Syntax Definition for OCaml|js}
   ; embedPath = {js|/videos/embed/a5b86864-8e43-4138-b6d6-ed48d2d4b63d|js}
   ; thumbnailPath = {js|/static/thumbnails/92c0a0e3-5326-42aa-86a3-6adb3927e111.jpg|js}
-  ; description = {js|In this talk, we present our work on a syntax definition for the OCaml language in the syntax definition formalism SDF3. SDF3 supports the high-level definition of concrete and abstract syntax through declarative disambiguation and definition of c...|js}
-  ; year = 2020
+  ; description = Some {js|In this talk, we present our work on a syntax definition for the OCaml language in the syntax definition formalism SDF3. SDF3 supports the high-level definition of concrete and abstract syntax through declarative disambiguation and definition of c...|js}
+  ; date = {js|2020-08-28T00:00:00.000Z|js}
   ; language = {js|Unknown|js}
   ; category = {js|Misc|js}
   };
@@ -120,8 +317,8 @@ against multiple OCaml versions and OS platforms...|js}
   { name = {js|LexiFi Runtime Types|js}
   ; embedPath = {js|/videos/embed/cc7e3242-0bef-448a-aa13-8827bba933e3|js}
   ; thumbnailPath = {js|/static/thumbnails/1d43d8b4-87d1-4398-b925-10a42460b8dc.jpg|js}
-  ; description = {js|OCaml programmers make deliberate use of abstract data types for composing safe and reliable software systems. The OCaml compiler relies on the invariants imposed by the type system to produce efficient and compact runtime data representations. Be...|js}
-  ; year = 2020
+  ; description = Some {js|OCaml programmers make deliberate use of abstract data types for composing safe and reliable software systems. The OCaml compiler relies on the invariants imposed by the type system to produce efficient and compact runtime data representations. Be...|js}
+  ; date = {js|2020-08-28T00:00:00.000Z|js}
   ; language = {js|Unknown|js}
   ; category = {js|Science & Technology|js}
   };
@@ -129,8 +326,8 @@ against multiple OCaml versions and OS platforms...|js}
   { name = {js|Types in Amber|js}
   ; embedPath = {js|/videos/embed/99b3dc75-9f93-4677-9f8b-076546725512|js}
   ; thumbnailPath = {js|/static/thumbnails/acd50ed1-43cf-45fd-a55e-9c40a6bf58ba.jpg|js}
-  ; description = {js|Coda is a new cryptocurrency that uses zk-SNARKs to dramatically reduce the size of data needed by nodes running its protocol. Nodes communicate in a format automatically derived from type definitions in OCaml source files. As the Coda software ev...|js}
-  ; year = 2020
+  ; description = Some {js|Coda is a new cryptocurrency that uses zk-SNARKs to dramatically reduce the size of data needed by nodes running its protocol. Nodes communicate in a format automatically derived from type definitions in OCaml source files. As the Coda software ev...|js}
+  ; date = {js|2020-08-28T00:00:00.000Z|js}
   ; language = {js|Unknown|js}
   ; category = {js|Misc|js}
   };
@@ -138,18 +335,138 @@ against multiple OCaml versions and OS platforms...|js}
   { name = {js|OCaml-CI : A Zero-Configuration CI|js}
   ; embedPath = {js|/videos/embed/da88d6ac-7ba1-4261-9308-d03fe21e35b9|js}
   ; thumbnailPath = {js|/static/thumbnails/1c22a14e-f067-4d4e-8e26-027cc6d8a491.jpg|js}
-  ; description = {js|OCaml-CI1 is a CI service for OCaml projects. It uses metadata from the project’s opam and dune files to work out what to build, and uses caching to make builds fast. It automatically tests projects against multiple OCaml versions and OS platforms...|js}
-  ; year = 2020
+  ; description = Some {js|OCaml-CI1 is a CI service for OCaml projects. It uses metadata from the project’s opam and dune files to work out what to build, and uses caching to make builds fast. It automatically tests projects against multiple OCaml versions and OS platforms...|js}
+  ; date = {js|2020-08-28T00:00:00.000Z|js}
   ; language = {js|English|js}
   ; category = {js|Science & Technology|js}
   };
  
-  { name = {js|History and key features of OCaml Language|js}
-  ; embedPath = {js|/videos/embed/64da4a9f-777e-478a-bd94-94ea8b57e570|js}
-  ; thumbnailPath = {js|/static/thumbnails/878b7470-9eea-4321-9276-3f888571c4e4.jpg|js}
-  ; description = {js|The OCaml programming language is a member of the ML language family pioneered by Robin Milner. An important feature of OCaml is that it reconciles the conciseness and flexibility of untyped programming languages (like Python, for example) with th...|js}
-  ; year = 2020
+  { name = {js|The OCaml Platform 1.0 - Reason ML|js}
+  ; embedPath = {js|/videos/embed/bd9a8e54-6ca5-4036-a08c-6a47cee6619e|js}
+  ; thumbnailPath = {js|/static/thumbnails/ddc1e6fb-9999-4e79-b458-31c7e3ec1108.jpg|js}
+  ; description = Some {js|Presented by Anil Madhavapeddy (@avsm)
+
+We keep being told ReasonML can compile to native and do interop with OCaml, and that there's a wealth of existing code and tools we can draw into our applications - but how do we get there?
+This video will ...|js}
+  ; date = {js|2018-12-11T00:00:00.000Z|js}
   ; language = {js|English|js}
-  ; category = {js|Education|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|State of the OCaml Platform|js}
+  ; embedPath = {js|/videos/embed/390ce74c-f85f-477d-8f20-504437409add|js}
+  ; thumbnailPath = {js|/static/thumbnails/33258292-009b-42ee-83d3-9eb4bfb4e048.jpg|js}
+  ; description = None
+  ; date = {js|2018-01-12T00:00:00.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Towards A Debugger for Native Code OCaml|js}
+  ; embedPath = {js|/videos/embed/b76f3301-261d-44f3-97ec-1910b45f6969|js}
+  ; thumbnailPath = {js|/static/thumbnails/93ea327e-5e8b-4844-b237-75719a7256b9.jpg|js}
+  ; description = None
+  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Operf: Benchmarking the OCaml Compiler|js}
+  ; embedPath = {js|/videos/embed/5a4a6c12-3cb1-40d2-a663-25f294e12555|js}
+  ; thumbnailPath = {js|/static/thumbnails/c2b5c90a-9c9e-4058-94a1-15525795a01a.jpg|js}
+  ; description = None
+  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Core Time stamp counter: A fast high resolution time source|js}
+  ; embedPath = {js|/videos/embed/75b4d60f-3e37-40bd-b025-f39dcce0c42c|js}
+  ; thumbnailPath = {js|/static/thumbnails/43248673-6478-4e96-b8ac-cd415d85569b.jpg|js}
+  ; description = None
+  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Specialization of Generic Array Accesses After Inlining|js}
+  ; embedPath = {js|/videos/embed/80553916-b90a-4641-93c8-35b000df04c1|js}
+  ; thumbnailPath = {js|/static/thumbnails/1f81fbbf-6fb0-4047-93a1-57759431166a.jpg|js}
+  ; description = None
+  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; language = {js|Unknown|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Inline Assembly in OCaml|js}
+  ; embedPath = {js|/videos/embed/632f520f-8f83-4b6f-89f1-5cde088436c7|js}
+  ; thumbnailPath = {js|/static/thumbnails/5d2f65d1-6129-4206-832b-c3d4bab410df.jpg|js}
+  ; description = None
+  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|The State of OCaml|js}
+  ; embedPath = {js|/videos/embed/60a2ecfb-86ea-4881-a279-0a928452a3c3|js}
+  ; thumbnailPath = {js|/static/thumbnails/a5e5f630-2df9-4691-8ddf-a8137001ab4c.jpg|js}
+  ; description = None
+  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|The State of the OCaml Platform|js}
+  ; embedPath = {js|/videos/embed/32475a83-b455-455b-937f-28e7185f4fc2|js}
+  ; thumbnailPath = {js|/static/thumbnails/7eb8af05-a6d5-4a88-89f3-146673a87cf0.jpg|js}
+  ; description = None
+  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Global Semantic Analysis on OCaml programs|js}
+  ; embedPath = {js|/videos/embed/51e4bdf0-50f7-4b13-8514-2d62b5341066|js}
+  ; thumbnailPath = {js|/static/thumbnails/8255d370-e621-44bc-b7c3-6dd39fab4d1d.jpg|js}
+  ; description = None
+  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Effective Concurrency through Algebraic Effects|js}
+  ; embedPath = {js|/videos/embed/e9f6c837-1435-4349-af0f-07d22d1c11ea|js}
+  ; thumbnailPath = {js|/static/thumbnails/1de58bd2-d2f9-428c-8b8c-97b48d6d2c7e.jpg|js}
+  ; description = None
+  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|A review of the growth of the OCaml community|js}
+  ; embedPath = {js|/videos/embed/f9d0b637-8aec-4bff-8c32-cd16b58023b6|js}
+  ; thumbnailPath = {js|/static/thumbnails/e573402b-1350-4aa7-a9ba-0e1c51198fb4.jpg|js}
+  ; description = None
+  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; language = {js|Unknown|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Persistent Networking with Irmin and MirageOS|js}
+  ; embedPath = {js|/videos/embed/97dd9634-28e4-4066-96e4-9c2036ee4bb2|js}
+  ; thumbnailPath = {js|/static/thumbnails/46ba8c5d-0f4a-427e-8e76-0c58cb0e70a7.jpg|js}
+  ; description = None
+  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
+  };
+ 
+  { name = {js|Ketrew and Biokepi|js}
+  ; embedPath = {js|/videos/embed/f3dcee35-bc04-453a-ba35-7aec90599661|js}
+  ; thumbnailPath = {js|/static/thumbnails/0a36e8ce-c415-4191-ad5b-6ef2eb23db4e.jpg|js}
+  ; description = None
+  ; date = {js|2015-09-18T00:00:00.000Z|js}
+  ; language = {js|English|js}
+  ; category = {js|Science & Technology|js}
   }]
 


### PR DESCRIPTION
This PR updates the watch.ocaml.org code in a few ways:
 - It renames the executable to `ood-watch` so the yaml can now be updated with `dune exec -- ood-watch > data/watch.yml`
 - It adds some logic to fetch all of the videos. The peertube API limits each request to `100` but you can offset that so the code does one request for the first batch to get the total number of videos and then dispatches the rest of the requests for whatever remains.
 - Records the full timestamp inline with #82 which I think makes sense here
 - Some videos don't have descriptions so these are now optional
 - Yaml 3 has some good fixes which we stumbled across so I thought I would set that lower bound too