### PR TITLE
Add french content for success stories

### DIFF
--- a/src/ood-gen/lib/success_story.ml
+++ b/src/ood-gen/lib/success_story.ml
@@ -16,9 +16,8 @@ type t = {
   body_html : string;
 }
 
-let all () =
-  Utils.map_files
-    (fun content ->
+let all =
+  Utils.map_files (fun content ->
       let metadata, body = Utils.extract_metadata_body content in
       let metadata = Utils.decode_or_raise metadata_of_yaml metadata in
       {
@@ -29,7 +28,10 @@ let all () =
         body_md = body;
         body_html = Omd.of_string body |> Omd.to_html;
       })
-    "success_stories/en"
+
+let all_en () = all "success_stories/en"
+
+let all_fr () = all "success_stories/fr"
 
 let pp ppf v =
   Fmt.pf ppf
@@ -58,6 +60,8 @@ type t =
   ; body_html : string
   }
   
-let all = %a
+let all_en = %a
+
+let all_fr = %a
 |}
-    pp_list (all ())
+    pp_list (all_en ()) pp_list (all_fr ())

--- a/src/ood-preview/lib/handlers/page_handler.ml
+++ b/src/ood-preview/lib/handlers/page_handler.ml
@@ -8,7 +8,7 @@ let papers _req =
   |> Dream.html
 
 let success_stories _req =
-  let success_stories = Ood.Success_story.all in
+  let success_stories = Ood.Success_story.all_en in
   Layout_template.render
     ~title:"Success Stories"
     (Success_stories_template.render success_stories)

--- a/src/ood/ood.ml
+++ b/src/ood/ood.ml
@@ -75,7 +75,9 @@ end
 module Success_story = struct
   include Success_story
 
-  let get_by_slug slug = List.find_opt (fun x -> String.equal slug x.slug) all
+  let all ?(lang = `English) () = match lang with | `English -> all_en | `French -> all_fr | _ -> all_en
+
+  let get_by_slug ?(lang) slug = List.find_opt (fun x -> String.equal slug x.slug) (all ?lang ())
 end
 
 module Tool = struct

--- a/src/ood/ood.mli
+++ b/src/ood/ood.mli
@@ -134,9 +134,13 @@ module Success_story : sig
     body_html : string;
   }
 
-  val all : t list
+  val all_en : t list
 
-  val get_by_slug : string -> t option
+  val all_fr : t list
+
+  val all : ?lang:[> `English | `French ] -> unit -> t list
+
+  val get_by_slug : ?lang:[> `English | `French ] -> string -> t option
 end
 
 module Tool : sig

--- a/src/ood/success_story.ml
+++ b/src/ood/success_story.ml
@@ -8,7 +8,7 @@ type t =
   ; body_html : string
   }
   
-let all = 
+let all_en = 
 [
   { title = {js|The ASTRÉE Static Analyzer|js}
   ; slug = {js|the-astre-static-analyzer|js}
@@ -441,6 +441,527 @@ maintain a high level of robustness through years of work by many
 different programmers. In fact, Unison may be unique among large OCaml
 projects in having been <em>translated</em> from Java to OCaml midway through
 its development. Moving to OCaml was like a breath of fresh air.”</p>
+|js}
+  }]
+
+let all_fr = 
+[
+  { title = {js|L'analyseur statique ASTRÉE|js}
+  ; slug = {js|lanalyseur-statique-astre|js}
+  ; image = Some {js|/success-stories/astree-thumb.gif|js}
+  ; url = Some {js|https://www.astree.ens.fr/|js}
+  ; body_md = {js|
+*[David Monniaux](https://www-verimag.imag.fr/~monniaux/) (CNRS), membre
+du projet ASTRÉE :* « [ASTRÉE](https://www.astree.ens.fr/) est un
+*analyseur statique* basé sur [l&#39;interprétation
+abstraite](https://www.di.ens.fr/%7Ecousot/aiintro.shtml) et qui vise à
+établir l'absence d'erreurs d'exécution dans des logiciels critiques
+écrits dans un sous-ensemble du langage C. »
+
+« Une analyse automatique et exacte visant à vérifier des propriétés
+telles que l'absence d'erreurs d'exécution est impossible en général,
+pour des raisons mathématiques. L'analyse statique par interprétation
+abstraite contourne cette impossibilité, et permet de prouver des
+propriétés de programmes, en sur-estimant l'ensemble des comportements
+possibles d'un programme. Il est possible de concevoir des
+approximations pessimistes qui, en pratique, permettent d'établir la
+propriété souhaitée pour une large gamme de logiciels. »
+
+« À ce jour, ASTRÉE a prouvé l'absence d'erreurs d'exécution dans le
+logiciel de contrôle primaire de la [famille Airbus
+A340](https://www.airbus.com/product/a330_a340_backgrounder.asp). Cela
+serait impossible par de simples *tests*, car le test ne considère qu'un
+*sous-ensemble* limité des cas, tandis que l'interprétation abstraite
+considère un *sur-ensemble* de tous les comportements possibles du
+système. »
+
+« [ASTRÉE](https://www.astree.ens.fr/) est écrit en OCaml et mesure
+environ 44000 lignes (plus des librairies externes). Nous avions besoin
+d'un langage doté d'une bonne performance (en termes de vitesse et
+d'occupation mémoire) sur un matériel raisonnable, favorisant l'emploi
+de structures de données avancées, et garantissant la sûreté mémoire.
+OCaml permet également d'organiser le code source de façon modulaire,
+claire et compacte, et facilite la gestion de structures de données
+récursives comme les arbres de syntaxe abstraite. »
+|js}
+  ; body_html = {js|<p><em><a href="https://www-verimag.imag.fr/~monniaux/">David Monniaux</a> (CNRS), membre
+du projet ASTRÉE :</em> « <a href="https://www.astree.ens.fr/">ASTRÉE</a> est un
+<em>analyseur statique</em> basé sur <a href="https://www.di.ens.fr/%7Ecousot/aiintro.shtml">l'interprétation
+abstraite</a> et qui vise à
+établir l'absence d'erreurs d'exécution dans des logiciels critiques
+écrits dans un sous-ensemble du langage C. »</p>
+<p>« Une analyse automatique et exacte visant à vérifier des propriétés
+telles que l'absence d'erreurs d'exécution est impossible en général,
+pour des raisons mathématiques. L'analyse statique par interprétation
+abstraite contourne cette impossibilité, et permet de prouver des
+propriétés de programmes, en sur-estimant l'ensemble des comportements
+possibles d'un programme. Il est possible de concevoir des
+approximations pessimistes qui, en pratique, permettent d'établir la
+propriété souhaitée pour une large gamme de logiciels. »</p>
+<p>« À ce jour, ASTRÉE a prouvé l'absence d'erreurs d'exécution dans le
+logiciel de contrôle primaire de la <a href="https://www.airbus.com/product/a330_a340_backgrounder.asp">famille Airbus
+A340</a>. Cela
+serait impossible par de simples <em>tests</em>, car le test ne considère qu'un
+<em>sous-ensemble</em> limité des cas, tandis que l'interprétation abstraite
+considère un <em>sur-ensemble</em> de tous les comportements possibles du
+système. »</p>
+<p>« <a href="https://www.astree.ens.fr/">ASTRÉE</a> est écrit en OCaml et mesure
+environ 44000 lignes (plus des librairies externes). Nous avions besoin
+d'un langage doté d'une bonne performance (en termes de vitesse et
+d'occupation mémoire) sur un matériel raisonnable, favorisant l'emploi
+de structures de données avancées, et garantissant la sûreté mémoire.
+OCaml permet également d'organiser le code source de façon modulaire,
+claire et compacte, et facilite la gestion de structures de données
+récursives comme les arbres de syntaxe abstraite. »</p>
+|js}
+  };
+ 
+  { title = {js|Coq|js}
+  ; slug = {js|coq|js}
+  ; image = Some {js|/success-stories/coq-thumb.jpg|js}
+  ; url = Some {js|https://coq.inria.fr/|js}
+  ; body_md = {js|
+*[Jean-Christophe Filliâtre](https://www.lri.fr/%7Efilliatr/) (CNRS), un
+des développeurs de Coq :* « L'outil [Coq](https://coq.inria.fr/) est un
+système de manipulation de preuves mathématiques formelles ; une preuve
+réalisée avec Coq est mécaniquement vérifiée par la machine. Outre ses
+applications en mathématiques, l'outil Coq permet également de certifier
+la correction de programmes informatiques. »
+
+« L'intérêt de OCaml du point de vue de Coq est multiple. D'une part, le
+langage OCaml est parfaitement adapté aux manipulations symboliques, qui
+sont prépondérantes dans un assistant de preuve. D'autre part, le
+système de types de OCaml, et notamment sa notion de type abstrait,
+permet une réelle encapsulation de la partie critique du code de Coq,
+garantissant ainsi la cohérence logique de l'ensemble du système. Enfin,
+le typage fort de OCaml assure de fait une grande qualité au code de Coq
+(tel que l'absence d'erreurs à l'exécution du type « segmentation
+fault »), ce qui est indispensable à un outil dont le but premier est
+justement la rigueur. »
+|js}
+  ; body_html = {js|<p><em><a href="https://www.lri.fr/%7Efilliatr/">Jean-Christophe Filliâtre</a> (CNRS), un
+des développeurs de Coq :</em> « L'outil <a href="https://coq.inria.fr/">Coq</a> est un
+système de manipulation de preuves mathématiques formelles ; une preuve
+réalisée avec Coq est mécaniquement vérifiée par la machine. Outre ses
+applications en mathématiques, l'outil Coq permet également de certifier
+la correction de programmes informatiques. »</p>
+<p>« L'intérêt de OCaml du point de vue de Coq est multiple. D'une part, le
+langage OCaml est parfaitement adapté aux manipulations symboliques, qui
+sont prépondérantes dans un assistant de preuve. D'autre part, le
+système de types de OCaml, et notamment sa notion de type abstrait,
+permet une réelle encapsulation de la partie critique du code de Coq,
+garantissant ainsi la cohérence logique de l'ensemble du système. Enfin,
+le typage fort de OCaml assure de fait une grande qualité au code de Coq
+(tel que l'absence d'erreurs à l'exécution du type « segmentation
+fault »), ce qui est indispensable à un outil dont le but premier est
+justement la rigueur. »</p>
+|js}
+  };
+ 
+  { title = {js|Le système de communication distribuée Ensemble|js}
+  ; slug = {js|le-systme-de-communication-distribue-ensemble|js}
+  ; image = None
+  ; url = Some {js|https://dsl.cs.technion.ac.il/projects/Ensemble/|js}
+  ; body_md = {js|
+*Ohad Rodeh (IBM Haifa), un des développeurs d'Ensemble :*
+« [Ensemble](https://dsl.cs.technion.ac.il/projects/Ensemble/) est un
+système de communication de groupe écrit en OCaml, développé à Cornell
+et à Hebrew University. À l'auteur d'applications, Ensemble fournit une
+librairie de protocoles que l'on peut utiliser pour construire
+rapidement des applications distribuées complexes. Pour un chercheur en
+systèmes distribués, Ensemble est une boîte à outils hautement modulaire
+et reconfigurable : les protocoles de haut niveau fournis aux
+applications sont en réalité des piles de minuscules « couches » de
+protocoles, dont chacune peut être modifiée ou reconstruite à des fins
+d'expérimentation. OCaml a été choisi initialement pour que le code
+puisse être vérifié par un prouveur de théorèmes semi-automatique. Ce
+code a ensuite fait ses preuves sur le terrain, et nous avons continué à
+développer en OCaml. Le système de types fort, les types de données
+algébriques, la récupération automatique de la mémoire et
+l'environnement d'exécution sont les principales raisons de notre
+intérêt pour OCaml. »
+|js}
+  ; body_html = {js|<p><em>Ohad Rodeh (IBM Haifa), un des développeurs d'Ensemble :</em>
+« <a href="https://dsl.cs.technion.ac.il/projects/Ensemble/">Ensemble</a> est un
+système de communication de groupe écrit en OCaml, développé à Cornell
+et à Hebrew University. À l'auteur d'applications, Ensemble fournit une
+librairie de protocoles que l'on peut utiliser pour construire
+rapidement des applications distribuées complexes. Pour un chercheur en
+systèmes distribués, Ensemble est une boîte à outils hautement modulaire
+et reconfigurable : les protocoles de haut niveau fournis aux
+applications sont en réalité des piles de minuscules « couches » de
+protocoles, dont chacune peut être modifiée ou reconstruite à des fins
+d'expérimentation. OCaml a été choisi initialement pour que le code
+puisse être vérifié par un prouveur de théorèmes semi-automatique. Ce
+code a ensuite fait ses preuves sur le terrain, et nous avons continué à
+développer en OCaml. Le système de types fort, les types de données
+algébriques, la récupération automatique de la mémoire et
+l'environnement d'exécution sont les principales raisons de notre
+intérêt pour OCaml. »</p>
+|js}
+  };
+ 
+  { title = {js|FFTW|js}
+  ; slug = {js|fftw|js}
+  ; image = Some {js|/success-stories/fftw-thumb.png|js}
+  ; url = Some {js|https://www.fftw.org/|js}
+  ; body_md = {js|
+[FFTW](https://www.fftw.org/) est une librairie C [très
+rapide](https://www.fftw.org/benchfft/) permettant d'effectuer des
+Transformées de Fourier Discrètes (DFT). Elle emploie un puissant
+optimiseur symbolique écrit en OCaml qui, étant donné un entier N,
+produit du code C hautement optimisé pour effectuer des DFTs de taille
+N. FFTW a reçu en 1999 le [prix
+Wilkinson](https://en.wikipedia.org/wiki/J._H._Wilkinson_Prize_for_Numerical_Software)
+pour les logiciels de calcul numérique.
+
+Des mesures effectuées sur diverses plate-formes montrent que les
+performances de FFTW sont typiquement supérieures à celles des autres
+logiciels de DFT disponibles publiquement, et peuvent même concurrencer
+le code optimisé proposé par certains fabriquants de processeurs. À la
+différence de ce code propriétaire, cependant, les performances de FFTW
+sont portables : un même programme donnera de bons résultats sur la
+plupart des architectures sans modification. D'où le nom « FFTW, » qui
+signifie « Fastest Fourier Transform in the West. »
+|js}
+  ; body_html = {js|<p><a href="https://www.fftw.org/">FFTW</a> est une librairie C <a href="https://www.fftw.org/benchfft/">très
+rapide</a> permettant d'effectuer des
+Transformées de Fourier Discrètes (DFT). Elle emploie un puissant
+optimiseur symbolique écrit en OCaml qui, étant donné un entier N,
+produit du code C hautement optimisé pour effectuer des DFTs de taille
+N. FFTW a reçu en 1999 le <a href="https://en.wikipedia.org/wiki/J._H._Wilkinson_Prize_for_Numerical_Software">prix
+Wilkinson</a>
+pour les logiciels de calcul numérique.</p>
+<p>Des mesures effectuées sur diverses plate-formes montrent que les
+performances de FFTW sont typiquement supérieures à celles des autres
+logiciels de DFT disponibles publiquement, et peuvent même concurrencer
+le code optimisé proposé par certains fabriquants de processeurs. À la
+différence de ce code propriétaire, cependant, les performances de FFTW
+sont portables : un même programme donnera de bons résultats sur la
+plupart des architectures sans modification. D'où le nom « FFTW, » qui
+signifie « Fastest Fourier Transform in the West. »</p>
+|js}
+  };
+ 
+  { title = {js|Haxe|js}
+  ; slug = {js|haxe|js}
+  ; image = None
+  ; url = Some {js|https://haxe.org/|js}
+  ; body_md = {js|
+[Haxe](https://haxe.org/)  est une boîte à outils open source basée sur un 
+langage de programmation moderne, de haut niveau, strictement typé, un 
+compilateur croisé, une bibliothèque standard multiplateforme complète et 
+des moyens d’accéder aux capacités natives de chaque plate-forme.Le compilateur 
+Haxe a été entièrement écrit dans OCaml.
+|js}
+  ; body_html = {js|<p><a href="https://haxe.org/">Haxe</a>  est une boîte à outils open source basée sur un
+langage de programmation moderne, de haut niveau, strictement typé, un
+compilateur croisé, une bibliothèque standard multiplateforme complète et
+des moyens d’accéder aux capacités natives de chaque plate-forme.Le compilateur
+Haxe a été entièrement écrit dans OCaml.</p>
+|js}
+  };
+ 
+  { title = {js|Jane Street|js}
+  ; slug = {js|jane-street|js}
+  ; image = Some {js|/success-stories/jane-street-thumb.jpg|js}
+  ; url = Some {js|https://janestreet.com/technology/|js}
+  ; body_md = {js|
+Jane Street est une société de négoce propriétaire qui utilise OCaml comme sa 
+plate-forme de développement primaire. Notre exploitation fonctionne à grande 
+échelle, générant des milliards de dollars de transactions chaque jour à partir 
+de nos bureaux de Hong Kong,Londres et New York, avec des stratégies qui couvrent 
+de nombreuses classes d’actifs, fuseaux horaires et régimes réglementaires.
+
+Presque tous nos logiciels sont écrits dans OCaml, du code de recherche statistique 
+aux outils d’administration des systèmes en retour de notre infrastructure de trading 
+en temps réel. Le système de type d’OCaml agit comme un ensemble riche et bien intégré 
+d’outils d’analyse statique qui aident à améliorer la qualité de notre code, en 
+attrapant les bogues le plus tôt possible. Chaque jour, des milliards de dollars de 
+transactions passent par nos systèmes, ce qui fait en sorte que les choses se passent 
+bien. Dans le même temps, OCaml est très productif, nous aidant à nous adapter rapidement 
+à l’évolution des conditions du marché.
+
+Jane Street contribue aux bibliothèques open-source à l’ensemble de la communauté depuis 
+de nombreuses années, y compris Core, notre bibliothèque standard alternative, Async, une 
+bibliothèque coopérative de concurrence, et plusieurs extensions syntaxiques comme binprot 
+et sexplib.Tous ces éléments peuvent être trouvés à 
+[https://janestreet.github.io](https://janestreet.github.io). Au total, nous avons ouvert
+plus de 200k lignes de code.
+|js}
+  ; body_html = {js|<p>Jane Street est une société de négoce propriétaire qui utilise OCaml comme sa
+plate-forme de développement primaire. Notre exploitation fonctionne à grande
+échelle, générant des milliards de dollars de transactions chaque jour à partir
+de nos bureaux de Hong Kong,Londres et New York, avec des stratégies qui couvrent
+de nombreuses classes d’actifs, fuseaux horaires et régimes réglementaires.</p>
+<p>Presque tous nos logiciels sont écrits dans OCaml, du code de recherche statistique
+aux outils d’administration des systèmes en retour de notre infrastructure de trading
+en temps réel. Le système de type d’OCaml agit comme un ensemble riche et bien intégré
+d’outils d’analyse statique qui aident à améliorer la qualité de notre code, en
+attrapant les bogues le plus tôt possible. Chaque jour, des milliards de dollars de
+transactions passent par nos systèmes, ce qui fait en sorte que les choses se passent
+bien. Dans le même temps, OCaml est très productif, nous aidant à nous adapter rapidement
+à l’évolution des conditions du marché.</p>
+<p>Jane Street contribue aux bibliothèques open-source à l’ensemble de la communauté depuis
+de nombreuses années, y compris Core, notre bibliothèque standard alternative, Async, une
+bibliothèque coopérative de concurrence, et plusieurs extensions syntaxiques comme binprot
+et sexplib.Tous ces éléments peuvent être trouvés à
+<a href="https://janestreet.github.io">https://janestreet.github.io</a>. Au total, nous avons ouvert
+plus de 200k lignes de code.</p>
+|js}
+  };
+ 
+  { title = {js|Le Langage de Modélisation Financière de LexiFi|js}
+  ; slug = {js|le-langage-de-modlisation-financire-de-lexifi|js}
+  ; image = Some {js|/success-stories/lexifi-thumb.jpg|js}
+  ; url = Some {js|https://www.lexifi.com/|js}
+  ; body_md = {js|
+Développé par la société [LexiFi](https://www.lexifi.com/), le Langage de
+Modélisation Financière (MLFi) est le premier langage formel capable de
+décrire les produits d'investissement, de crédit et de marché de
+capitaux les plus sophistiqués. MLFi est implanté comme une extension
+d'OCaml.
+
+Les utilisateurs de MLFi retirent deux importants bénéfices de
+l'approche par programmation fonctionnelle. D'abord, le formalisme
+déclaratif des langages de programmation fonctionnels est adapté à la
+*spécification* de structures de données et d'algorithmes complexes.
+Ensuite, ces langages offrent de nombreuses facilités pour la
+manipulation des listes. Or, les listes jouent un rôle central en
+finance, où elles sont utilisées de façon intensive pour définir des
+agendas d'événements de contrats et de paiements.
+
+De plus, MLFi est doté de capacités d'intégration cruciales, héritées
+d'OCaml et des outils et librairies qui l'accompagnent, Cela permet aux
+utilisateurs, par exemple, d'interopérer avec des programmes C et Java,
+de manipuler des schémas et documents XML, et de s'interfacer avec des
+bases de données SQL.
+
+Des modèles de données et modèles objets visant à encapsuler les
+définitions et le comportement des instruments financiers ont été
+développés par l'industrie bancaire depuis deux décennies, mais font
+face à des limitations inhérentes qu'OCaml a aidé à surpasser.
+
+L'approche de LexiFi pour la modélisation de contrats financiers
+complexes a reçu une récompense académique en 2000, et l'implantation de
+MLFi a été nommée « Produit Logiciel de l'Année 2001 » par le magazine
+*Risk*, la principale publication dans le domaine des échanges
+financiers et de la gestion des risques. Les solutions basées sur MLFi
+gagnent en reconnaissance à travers l'Europe et contribuent à répandre
+l'utilisation d'OCaml dans l'industrie des services financiers.
+|js}
+  ; body_html = {js|<p>Développé par la société <a href="https://www.lexifi.com/">LexiFi</a>, le Langage de
+Modélisation Financière (MLFi) est le premier langage formel capable de
+décrire les produits d'investissement, de crédit et de marché de
+capitaux les plus sophistiqués. MLFi est implanté comme une extension
+d'OCaml.</p>
+<p>Les utilisateurs de MLFi retirent deux importants bénéfices de
+l'approche par programmation fonctionnelle. D'abord, le formalisme
+déclaratif des langages de programmation fonctionnels est adapté à la
+<em>spécification</em> de structures de données et d'algorithmes complexes.
+Ensuite, ces langages offrent de nombreuses facilités pour la
+manipulation des listes. Or, les listes jouent un rôle central en
+finance, où elles sont utilisées de façon intensive pour définir des
+agendas d'événements de contrats et de paiements.</p>
+<p>De plus, MLFi est doté de capacités d'intégration cruciales, héritées
+d'OCaml et des outils et librairies qui l'accompagnent, Cela permet aux
+utilisateurs, par exemple, d'interopérer avec des programmes C et Java,
+de manipuler des schémas et documents XML, et de s'interfacer avec des
+bases de données SQL.</p>
+<p>Des modèles de données et modèles objets visant à encapsuler les
+définitions et le comportement des instruments financiers ont été
+développés par l'industrie bancaire depuis deux décennies, mais font
+face à des limitations inhérentes qu'OCaml a aidé à surpasser.</p>
+<p>L'approche de LexiFi pour la modélisation de contrats financiers
+complexes a reçu une récompense académique en 2000, et l'implantation de
+MLFi a été nommée « Produit Logiciel de l'Année 2001 » par le magazine
+<em>Risk</em>, la principale publication dans le domaine des échanges
+financiers et de la gestion des risques. Les solutions basées sur MLFi
+gagnent en reconnaissance à travers l'Europe et contribuent à répandre
+l'utilisation d'OCaml dans l'industrie des services financiers.</p>
+|js}
+  };
+ 
+  { title = {js|Liquidsoap|js}
+  ; slug = {js|liquidsoap|js}
+  ; image = None
+  ; url = None
+  ; body_md = {js|
+[Liquidsoap](https://www.liquidsoap.info/) est clairement bien établie dans 
+l’industrie de la radio (internet).Liquidsoap est bien connu comme un 
+outil avec des capacités uniques, et a beaucoup d’utilisateurs, y compris 
+les grands commerciaux.Il n’est pas développé comme une entreprise, mais les 
+entreprises développent des services ou des logiciels sur le dessus de celui-ci.
+Par exemple, Sourcefabric développe et vend du temps d’antenne au-dessus de Liquidsoap.
+|js}
+  ; body_html = {js|<p><a href="https://www.liquidsoap.info/">Liquidsoap</a> est clairement bien établie dans
+l’industrie de la radio (internet).Liquidsoap est bien connu comme un
+outil avec des capacités uniques, et a beaucoup d’utilisateurs, y compris
+les grands commerciaux.Il n’est pas développé comme une entreprise, mais les
+entreprises développent des services ou des logiciels sur le dessus de celui-ci.
+Par exemple, Sourcefabric développe et vend du temps d’antenne au-dessus de Liquidsoap.</p>
+|js}
+  };
+ 
+  { title = {js|Le client pair-à-pair MLdonkey|js}
+  ; slug = {js|le-client-pair--pair-mldonkey|js}
+  ; image = Some {js|/success-stories/mldonkey-thumb.jpg|js}
+  ; url = Some {js|https://mldonkey.sourceforge.net/Main_Page|js}
+  ; body_md = {js|
+[MLdonkey](https://mldonkey.sourceforge.net/Main_Page) est un client
+pair-à-pair multi-plateformes et multi-réseaux. Il a été le premier
+client « open source » à permettre l'accès au réseau eDonkey.
+Aujourd'hui, MLdonkey autorise également l'accès à plusieurs autres
+réseaux importants, parmi lesquels Overnet, Bittorrent, Gnutella,
+Gnutella2, Fasttrack, Soulseek, Direct-Connect et Opennap. Il permet
+d'effectuer une recherche en parallèle sur plusieurs réseaux, et échange
+des fichiers avec de multiples pairs en parallèle.
+
+*Un des développeurs de MLdonkey :* « Début 2002, nous avons décidé
+d'utiliser OCaml pour programmer une application réseau dans le monde
+émergent des systèmes pair-à-pair. Le résultat de notre travail,
+MLdonkey, a surpassé nos espérances : MLdonkey est aujourd'hui le client
+de partage de fichiers pair-à-pair le plus populaire, d'après
+[freshmeat.net](https://freshmeat.net/), avec environ dix mille
+utilisateurs quotidiens. De plus, MLdonkey est le seul client capable de
+se connecter à plusieurs réseaux pair-à-pair pour télécharger et
+échanger des fichiers. Il fonctionne en tant que démon, c'est-à-dire en
+tâche de fond et sans surveillance humaine, et peut être contrôlé à
+l'aide d'une interface au choix parmi trois : GTK, web et telnet. »
+|js}
+  ; body_html = {js|<p><a href="https://mldonkey.sourceforge.net/Main_Page">MLdonkey</a> est un client
+pair-à-pair multi-plateformes et multi-réseaux. Il a été le premier
+client « open source » à permettre l'accès au réseau eDonkey.
+Aujourd'hui, MLdonkey autorise également l'accès à plusieurs autres
+réseaux importants, parmi lesquels Overnet, Bittorrent, Gnutella,
+Gnutella2, Fasttrack, Soulseek, Direct-Connect et Opennap. Il permet
+d'effectuer une recherche en parallèle sur plusieurs réseaux, et échange
+des fichiers avec de multiples pairs en parallèle.</p>
+<p><em>Un des développeurs de MLdonkey :</em> « Début 2002, nous avons décidé
+d'utiliser OCaml pour programmer une application réseau dans le monde
+émergent des systèmes pair-à-pair. Le résultat de notre travail,
+MLdonkey, a surpassé nos espérances : MLdonkey est aujourd'hui le client
+de partage de fichiers pair-à-pair le plus populaire, d'après
+<a href="https://freshmeat.net/">freshmeat.net</a>, avec environ dix mille
+utilisateurs quotidiens. De plus, MLdonkey est le seul client capable de
+se connecter à plusieurs réseaux pair-à-pair pour télécharger et
+échanger des fichiers. Il fonctionne en tant que démon, c'est-à-dire en
+tâche de fond et sans surveillance humaine, et peut être contrôlé à
+l'aide d'une interface au choix parmi trois : GTK, web et telnet. »</p>
+|js}
+  };
+ 
+  { title = {js|SLAM|js}
+  ; slug = {js|slam|js}
+  ; image = None
+  ; url = Some {js|https://research.microsoft.com/en-us/projects/slam/|js}
+  ; body_md = {js|
+Le projet [SLAM](https://research.microsoft.com/en-us/projects/slam/) a
+débuté à Microsoft Research début 2000. Son but était de vérifier
+automatiquement qu'un programme C utilise correctement l'interface d'une
+bibliothèque extérieure. Pour répondre à cette question, SLAM utilise de
+manière novatrice des idées provenant de la vérification symbolique de
+modèles, de l'analyse statique de programmes et de la démonstration
+automatique. Le moteur d'analyse SLAM est au coeur d'un nouvel outil
+appelé SDV (Vérification Statique de Drivers) qui analyse
+systématiquement le code source des drivers (pilotes de périphériques)
+Windows et vérifie leur conformité vis-à-vis d'un ensemble de règles qui
+caractérisent les interactions correctes entre un driver et le noyau du
+système d'exploitation Windows.
+
+*Dans le rapport technique
+[MSR-TR-2004-08](https://research.microsoft.com/apps/pubs/default.aspx?id=70038),
+T.Ball, B.Cook, V.Levin and S.K.Rajamani, les auteurs de SLAM,
+écrivent:* “The Right Tools for the Job: We developed SLAM using Inria's
+OCaml functional programming language. The expressiveness of this
+language and robustness of its implementation provided a great
+productivity boost.”
+|js}
+  ; body_html = {js|<p>Le projet <a href="https://research.microsoft.com/en-us/projects/slam/">SLAM</a> a
+débuté à Microsoft Research début 2000. Son but était de vérifier
+automatiquement qu'un programme C utilise correctement l'interface d'une
+bibliothèque extérieure. Pour répondre à cette question, SLAM utilise de
+manière novatrice des idées provenant de la vérification symbolique de
+modèles, de l'analyse statique de programmes et de la démonstration
+automatique. Le moteur d'analyse SLAM est au coeur d'un nouvel outil
+appelé SDV (Vérification Statique de Drivers) qui analyse
+systématiquement le code source des drivers (pilotes de périphériques)
+Windows et vérifie leur conformité vis-à-vis d'un ensemble de règles qui
+caractérisent les interactions correctes entre un driver et le noyau du
+système d'exploitation Windows.</p>
+<p><em>Dans le rapport technique
+<a href="https://research.microsoft.com/apps/pubs/default.aspx?id=70038">MSR-TR-2004-08</a>,
+T.Ball, B.Cook, V.Levin and S.K.Rajamani, les auteurs de SLAM,
+écrivent:</em> “The Right Tools for the Job: We developed SLAM using Inria's
+OCaml functional programming language. The expressiveness of this
+language and robustness of its implementation provided a great
+productivity boost.”</p>
+|js}
+  };
+ 
+  { title = {js|Le synchroniseur de fichiers Unison|js}
+  ; slug = {js|le-synchroniseur-de-fichiers-unison|js}
+  ; image = Some {js|/success-stories/unison-thumb.jpg|js}
+  ; url = Some {js|https://www.cis.upenn.edu/%7Ebcpierce/unison/|js}
+  ; body_md = {js|
+[Unison](https://www.cis.upenn.edu/%7Ebcpierce/unison/) est un outil de
+synchronisation de fichiers populaire, qui fonctionne sous Windows et
+sous la plupart des variantes d'Unix. Il permet de stocker deux
+répliques d'une collection de fichiers et de répertoires sur deux
+machines différentes, ou bien sur deux disques différents d'une même
+machine, et de les mettre à jour en propageant les changements de
+chacune des répliques vers l'autre. À la différence d'un simple outil de
+sauvegarde ou de maintien d'une image miroir, Unison est capable de
+gérer la situation où les deux répliques ont été modifiées : les
+changements qui n'entrent pas en conflit sont propagés automatiquement,
+tandis que les changements incompatibles sont détectés et signalés.
+Unison est également résistant aux échecs : il prend soin de laisser les
+deux répliques, ainsi que ses propres structures privées, dans un état
+cohérent à tout instant, même en cas d'arrêt abrupt ou de panne de
+communication.
+
+*[Benjamin C. Pierce](https://www.cis.upenn.edu/%7Ebcpierce/) (University
+of Pennsylvania), chef du projet Unison :* « Je pense qu'Unison est un
+succès très clair pour OCaml – en particulier, grâce à l'extrême
+portabilité et l'excellente conception générale du compilateur et de
+l'environnement d'exécution. Le typage statique fort d'OCaml, ainsi que
+son puissant système de modules, nous ont aidés à organiser un logiciel
+complexe et de grande taille avec un haut degré d'encapsulation. Ceci
+nous a permis de préserver un haut niveau de robustesse, au cours de
+plusieurs années de travail, et avec la participation de nombreux
+programmeurs. En fait, Unison présente la caractéristique, peut-être
+unique parmi les projets de grande taille écrits en OCaml, d'avoir été
+*traduit* de Java vers OCaml à mi-chemin au cours de son développement.
+L'adoption d'OCaml a été comme une bouffée d'air pur. »
+|js}
+  ; body_html = {js|<p><a href="https://www.cis.upenn.edu/%7Ebcpierce/unison/">Unison</a> est un outil de
+synchronisation de fichiers populaire, qui fonctionne sous Windows et
+sous la plupart des variantes d'Unix. Il permet de stocker deux
+répliques d'une collection de fichiers et de répertoires sur deux
+machines différentes, ou bien sur deux disques différents d'une même
+machine, et de les mettre à jour en propageant les changements de
+chacune des répliques vers l'autre. À la différence d'un simple outil de
+sauvegarde ou de maintien d'une image miroir, Unison est capable de
+gérer la situation où les deux répliques ont été modifiées : les
+changements qui n'entrent pas en conflit sont propagés automatiquement,
+tandis que les changements incompatibles sont détectés et signalés.
+Unison est également résistant aux échecs : il prend soin de laisser les
+deux répliques, ainsi que ses propres structures privées, dans un état
+cohérent à tout instant, même en cas d'arrêt abrupt ou de panne de
+communication.</p>
+<p><em><a href="https://www.cis.upenn.edu/%7Ebcpierce/">Benjamin C. Pierce</a> (University
+of Pennsylvania), chef du projet Unison :</em> « Je pense qu'Unison est un
+succès très clair pour OCaml – en particulier, grâce à l'extrême
+portabilité et l'excellente conception générale du compilateur et de
+l'environnement d'exécution. Le typage statique fort d'OCaml, ainsi que
+son puissant système de modules, nous ont aidés à organiser un logiciel
+complexe et de grande taille avec un haut degré d'encapsulation. Ceci
+nous a permis de préserver un haut niveau de robustesse, au cours de
+plusieurs années de travail, et avec la participation de nombreux
+programmeurs. En fait, Unison présente la caractéristique, peut-être
+unique parmi les projets de grande taille écrits en OCaml, d'avoir été
+<em>traduit</em> de Java vers OCaml à mi-chemin au cours de son développement.
+L'adoption d'OCaml a été comme une bouffée d'air pur. »</p>
 |js}
   }]
 


### PR DESCRIPTION
This PR adds the french content for the success stories (the only translated content for now).

Since this is the first instance of an API to work the translated content, feedback on the proposed API is welcome and important.

- We add an `all_{lang}` function for each available language (`en` and `fr` here)
- We change the `all` function to `val all : ?lang:[> `English | `French ] -> unit -> t list`, where `lang` is optional and defaults to `English`
- Similarly, we change the `get_by_slug` function to take an optional `lang` argument.