### PR TITLE
Add a note about the repository's new home

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+❗ **This repository has moved to https://github.com/ocaml/v3.ocaml.org-server. Please open issues and PRs there.**
+
 Typed and Versioned Data for OCaml.org v3
 -----------------------------------------
 


### PR DESCRIPTION
This adds a note in the README to redirect users to https://github.com/ocaml/v3.ocaml.org-server.

@patricoferris I've transferred the important issues to the new repository. Do you see anything else to do to transition properly?